### PR TITLE
Ensure user-service docker image is fetched when building bichard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,11 @@ jobs:
           name: Clear out the networks before we start our Docker services
           command: docker network prune -f
       - run:
+          name: Fetch the user-service image
+          command: |
+            cd ~/bichard7-next
+            bash scripts/fetch_user_service_docker.sh
+      - run:
           name: Run docker services (except BeanConnect)
           command: |
             cd ~/bichard7-next


### PR DESCRIPTION
After merging in [this PR in the bichard7-next repo](https://github.com/ministryofjustice/bichard7-next/pull/272), the CI in this repo was breaking due to not being able to fetch the `user-service` docker image:

```
ERROR: The image for the service you're trying to recreate has been removed. If you continue, volume data could be lost. Consider backing up your data before continuing.
Continue with the new image? [yN]ERROR: pull access denied for user-service, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

([source](https://app.circleci.com/pipelines/github/ministryofjustice/bichard7-next-tests/98/workflows/dffa54cb-bd37-4895-b822-585002adb3ff/jobs/274))

This PR makes sure the `bichard7-next/scripts/fetch_user_service_docker.sh` script is called before running the commands from the makefile that try to use the image.