### PR TITLE
Ensure lint-staged config only matches our feature files and not q-solution-import

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       "eslint --fix",
       "prettier -w"
     ],
-    "*.feature": [
+    "features/**/*.feature": [
       "gherkin-lint"
     ]
   }


### PR DESCRIPTION
As the title says, this PR tweaks the lint-staged configuration to only run `gherkin-lint` against modified feature files in the `features` directly. Previously this was also matching against feature files in the `q-solution-import` directory, which was causing a few headaches.