### PR TITLE
Use full DNS name for user-service host address

### DIFF
--- a/scripts/setup-e2e-tests.sh
+++ b/scripts/setup-e2e-tests.sh
@@ -46,7 +46,7 @@ fi
 AWS_CLI_PATH="$(which aws)"
 PNC_ELB_NAME=$(echo "cjse-${WORKSPACE}-bichard-7-pncemulator" | cut -c1-32)
 aws_credential_check
-HOSTED_ZONE=$($AWS_CLI_PATH route53 list-hosted-zones-by-name --query "HostedZones[?contains(Name, 'justice.gov.uk') && contains(Name, '${WORKSPACE}')].Name" --output text)
+HOSTED_ZONE=$($AWS_CLI_PATH route53 list-hosted-zones-by-name --query "HostedZones[?contains(Name, 'justice.gov.uk') && contains(Name, '${WORKSPACE}')].Name" --output text | sed 's/\.$//')
 UI_HOST="app.${HOSTED_ZONE}"
 USERS_HOST="users.${HOSTED_ZONE}"
 PNC_HOST=$($AWS_CLI_PATH elbv2 describe-load-balancers --names ${PNC_ELB_NAME} --query 'LoadBalancers[0].DNSName' --output text)


### PR DESCRIPTION
We need to make sure we visit the user-service through the `*.justice.gov.uk` hostname, rather than the amazonaws.com hostname, to ensure that the browser doesn't reject our session cookies on the grounds of CSRF protection...