### PR TITLE
Use rmSync with the force option instead of rmDirSync

### DIFF
--- a/steps/hooks.js
+++ b/steps/hooks.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 BeforeAll(async () => {
   const clearRecordings = process.env.CLEAR_RECORDINGS !== "false";
   if (clearRecordings) {
-    fs.rmdirSync("./screenshots", { recursive: true });
+    fs.rmSync("./screenshots", { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
If the screenshots directory doesn't exist, then [rmDirSync throws an `ENOENT: no such file or directory` error](https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/497078235711/projects/integration-test-e2e-test/build/integration-test-e2e-test%3A003da61e-09e3-48f0-a91e-e1b205bcb819?region=eu-west-2).

Using `rmSync` with `recursive` and `force` mimicks the behaviour of `rm -rf`, meaning errors will be ignored if the path doesn't exist.