### PR TITLE
Update user-service login flow to use multi-step email verification

### DIFF
--- a/helpers/PostgresHelper.js
+++ b/helpers/PostgresHelper.js
@@ -21,6 +21,17 @@ class PostgresHelper {
   async dumpData() {
     return global.postgresConnection.any("select * from BR7OWN.ERROR_LIST");
   }
+
+  // eslint-disable-next-line class-methods-use-this
+  async getEmailVerificationCode(emailAddress) {
+    const query = `
+      SELECT email_verification_code
+      FROM br7own.users
+      WHERE email = $1
+    `;
+    const result = await global.postgresConnection.one(query, emailAddress);
+    return result.email_verification_code;
+  }
 }
 
 module.exports = PostgresHelper;

--- a/utils/urls.js
+++ b/utils/urls.js
@@ -8,11 +8,13 @@ const authenticateUrl = (token) => url(`/bichard-ui/Authenticate?token=${token}`
 const logout = () => url("/bichard-ui/bichard-lo");
 
 const userService = () => getConfig().usersUrl;
+const userServiceVerification = (emailToken) => `${userService()}/login/verify?token=${emailToken}`;
 
 module.exports = {
   home,
   initialRefreshUrl,
+  authenticateUrl,
   logout,
   userService,
-  authenticateUrl
+  userServiceVerification
 };


### PR DESCRIPTION
This PR adds support to the end-to-end tests for logging in with the user-service multi-step authentication:

1. Visit user service, enter email
2. Fetch email verification code from database
3. Generate email verification JWT, and therefore the verification link
4. Visit the verification link, enter password

This logic is only used when `$AUTH_TYPE` is set to `user-service` - all other authentication cases (`bichard`, `bichard-jwt`) will function as before.