### PR TITLE
Add npm script for running all tests tagged with '@Must'

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:file": "./scripts/prepare-environment.sh && ./node_modules/.bin/cucumber-js --format @cucumber/pretty-formatter --require steps --no-strict --exit --publish-quiet",
     "test:file-parallel": "./scripts/prepare-environment.sh && ./node_modules/.bin/cucumber-js --format @cucumber/pretty-formatter --require steps --no-strict --exit --publish-quiet --parallel",
     "test:local-next": "AWS_URL=\"http://localhost:4566\" WORKSPACE=local-next STACK_TYPE=next npm run test",
+    "test:must": "./scripts/prepare-environment.sh && ./node_modules/.bin/cucumber-js --require steps --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter --fail-fast --tags '@Must' features",
     "test:baseline": "STACK_TYPE=baseline npm run test",
     "test:baseline:legacy": "STACK_TYPE=baseline AUTH_TYPE=bichard ./node_modules/.bin/cucumber-js --require steps --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter --fail-fast --tags 'not @Excluded and not @ExcludedOnBaseline and not @OnlyRunsOnPNC'",
     "test:browser": "HEADLESS=false npm run test",


### PR DESCRIPTION
As the title says. Allows easy running of all `Must`-tagged tests via `npm run test:must`.