### PR TITLE
Disable audit logging in e2e tests buildspec

### DIFF
--- a/e2eTestBuildspec.yml
+++ b/e2eTestBuildspec.yml
@@ -24,7 +24,7 @@ phases:
       - npm i
       - source ./workspaces/${WORKSPACE}.env
       - CI=true RECORD=true npm run ${TEST_COMMAND}
-      - CI=true RECORD=true MESSAGE_ENTRY_POINT=s3 npm run ${AL_TEST_COMMAND}
+      - CI=true RECORD=true MESSAGE_ENTRY_POINT=mq npm run ${AL_TEST_COMMAND}
   post_build:
     commands:
       - unset AWS_SESSION_TOKEN


### PR DESCRIPTION
This PR disables uploading messages to S3 for audit logs tests temporarily until the access to audit log API is fixed.