### PR TITLE
Update auditlogs npm command to exclude real pnc tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:js": "eslint --fix .",
     "lint:features": "gherkin-lint features",
     "test": "./scripts/prepare-environment.sh && ./node_modules/.bin/cucumber-js --require steps --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter --fail-fast --tags 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC and not @AuditLog' features",
-    "test:auditlogs": "./scripts/prepare-environment.sh && echo $PNC_HOST && ./node_modules/.bin/cucumber-js --require steps --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter --fail-fast --tags '@AuditLog and not @Excluded' features",
+    "test:auditlogs": "./scripts/prepare-environment.sh && echo $PNC_HOST && ./node_modules/.bin/cucumber-js --require steps --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter --fail-fast --tags '@AuditLog and not @OnlyRunsOnPNC and not @Excluded' features",
     "test:preprodauditlogs": "./scripts/prepare-environment.sh && ./node_modules/.bin/cucumber-js --require steps --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter --fail-fast --tags '@AuditLog and not @ExcludeOnPreProd and not @Excluded' features",
     "test:preprod": "./scripts/prepare-environment.sh && SKIP_PNC_VALIDATION=true ./node_modules/.bin/cucumber-js --require steps --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter --fail-fast --tags '@OnlyRunsOnPNC and not @AuditLog' features",
     "test:loadtest-ui": "./scripts/prepare-environment.sh && PRINT_ENV=true RUN_PARALLEL=true ./node_modules/.bin/cucumber-js --require steps --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter --tags '@LoadTestUI' features",


### PR DESCRIPTION
Updated `npm run test:auditlogs` command to exclude tests that are meant to run against the real PNC.