### PR TITLE
Feature/bicaws 1344 external incoming messages bucket

### DIFF
--- a/scripts/setup-e2e-tests.sh
+++ b/scripts/setup-e2e-tests.sh
@@ -58,7 +58,7 @@ BROKER_ID=$(aws mq list-brokers --query "BrokerSummaries[?BrokerName=='cjse-${WO
 BROKER_ENDPOINTS=$(aws mq describe-broker --broker-id ${BROKER_ID} --query "join(',', BrokerInstances[*].Endpoints[2])" --output text)
 BROKER_URL="failover:(${BROKER_ENDPOINTS})"
 DB_HOST=$($AWS_CLI_PATH rds describe-db-clusters --region eu-west-2 --filters Name=db-cluster-id,Values=cjse-${WORKSPACE}-bichard-7-aurora-cluster --query "DBClusters[0].Endpoint" --output text)
-S3_INCOMING_MESSAGE_BUCKET=$(aws lambda list-functions --query "Functions[?contains(FunctionName, 'transfer-messages')].Environment.Variables.EXTERNAL_INCOMING_MESSAGE_BUCKET_NAME" --output text)
+S3_INCOMING_MESSAGE_BUCKET=$(aws lambda list-functions --query "Functions[?contains(FunctionName, 'transfer-messages') && contains(FunctionName, '-${WORKSPACE}-')].Environment.Variables.EXTERNAL_INCOMING_MESSAGE_BUCKET_NAME" --output text)
 S3_REGION="$AWS_REGION"
 INCOMING_MESSAGE_HANDLER_REGION="$AWS_REGION"
 AUDIT_LOGGING_DYNAMODB_TABLE="bichard-7-${WORKSPACE}-audit-log"

--- a/scripts/setup-e2e-tests.sh
+++ b/scripts/setup-e2e-tests.sh
@@ -58,7 +58,7 @@ BROKER_ID=$(aws mq list-brokers --query "BrokerSummaries[?BrokerName=='cjse-${WO
 BROKER_ENDPOINTS=$(aws mq describe-broker --broker-id ${BROKER_ID} --query "join(',', BrokerInstances[*].Endpoints[2])" --output text)
 BROKER_URL="failover:(${BROKER_ENDPOINTS})"
 DB_HOST=$($AWS_CLI_PATH rds describe-db-clusters --region eu-west-2 --filters Name=db-cluster-id,Values=cjse-${WORKSPACE}-bichard-7-aurora-cluster --query "DBClusters[0].Endpoint" --output text)
-S3_INCOMING_MESSAGE_BUCKET=$(aws lambda list-functions --query "Functions[?contains(FunctionName, 'retrieve-from-s3')].Environment.Variables.INCOMING_MESSAGE_BUCKET_NAME" --output text)
+S3_INCOMING_MESSAGE_BUCKET=$(aws lambda list-functions --query "Functions[?contains(FunctionName, 'transfer-messages')].Environment.Variables.EXTERNAL_INCOMING_MESSAGE_BUCKET_NAME" --output text)
 S3_REGION="$AWS_REGION"
 INCOMING_MESSAGE_HANDLER_REGION="$AWS_REGION"
 AUDIT_LOGGING_DYNAMODB_TABLE="bichard-7-${WORKSPACE}-audit-log"

--- a/steps/auditLogging.js
+++ b/steps/auditLogging.js
@@ -6,7 +6,7 @@ const checkEventByExternalCorreationId = async (context, externalCorrelationId, 
   const getMessages = () => auditLogDynamoDb.getMessageByExternalCorrelationId(externalCorrelationId);
 
   const options = {
-    timeout: 20000,
+    timeout: 40000,
     delay: 1000,
     name: eventType,
     condition: (message) => {


### PR DESCRIPTION
- Updated `setup-e2e-tests.sh` script to get the external incoming messages bucket name.
- Increased the timeout for the audit logging step to 40 seconds