### PR TITLE
Run characterisation tests in codebuild

### DIFF
--- a/characterisation/jest.config.js
+++ b/characterisation/jest.config.js
@@ -2,9 +2,8 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  modulePathIgnorePatterns: ["node_modules", "build"],
-  testMatch: ["**/*.test.ts"],
   // Run these files after jest has been
   // installed in the environment
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"]
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  verbose: true
 };

--- a/scripts/run-pipeline-tests.sh
+++ b/scripts/run-pipeline-tests.sh
@@ -15,8 +15,8 @@ then
     CI=true RECORD=true npm run test:must
     CI=true RECORD=true MESSAGE_ENTRY_POINT=s3 npm run test:must:auditlogs
   fi
-  # echo "Running characterisation tests"
-  # npm run test:characterisation
+  echo "Running characterisation tests"
+  npm run test:characterisation
 elif [ $WORKSPACE = "preprod" ]
 then
   echo "Running preprod tests"


### PR DESCRIPTION
This PR will set the codebuild job `integration-test-e2e-test` run as part of the deploy pipeline to also run the characterisation tests

For an example of the codebuild job output when running the characterisation tests, see https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/497078235711/projects/integration-test-e2e-test/build/integration-test-e2e-test%3Ab98f1502-6cdc-4289-9d49-c2132e6014b4/?region=eu-west-2

`testMatch` was removed from the jest config as it was causing jest to not find the test files in codebuild, but the default value works