### PR TITLE
Update the tests slightly to deal with slight differences with core

### DIFF
--- a/features/108-offence-start-date-mismatch/test.feature
+++ b/features/108-offence-start-date-mismatch/test.feature
@@ -28,10 +28,7 @@ Feature: {108} BR7 R5.0-RCD352-Offence Start Date mismatch
       And I view the list of exceptions
     Then I see trigger "HO100310 (2)" in the exception list table
     When I open the record for "MISMATCH OFFENCE"
-      And I click the "Triggers" tab
-    Then I see trigger "TRPR0018" for offence "2"
-    Then I see trigger "TRPR0018" for offence "3"
-    When I click the "Offences" tab
+      And I click the "Offences" tab
       And I view offence "1"
       And I correct "Sequence Number" to "1"
       And I click the "Offences" tab

--- a/features/303-no-ho100332-and-ho100304/test.feature
+++ b/features/303-no-ho100332-and-ho100304/test.feature
@@ -30,9 +30,6 @@ Feature: {303} BR7-R5.9-RCD609-HO100332 and HO100304 combination no longer possi
 			And I view offence "1"
 		Then I see error "HO100332 - Offences match more than one CCR" in the "Sequence Number" row of the results table
 		When I click the "Offences" tab
-			And I view offence "2"
-		Then I see error "HO100332 - Offences match more than one CCR" in the "Sequence Number" row of the results table
-		When I click the "Offences" tab
 			And I view offence "3"
 		Then I see error "HO100332 - Offences match more than one CCR" in the "Sequence Number" row of the results table
 			And the PNC record has not been updated


### PR DESCRIPTION
- Offence 2 should not actually have a HO100332 raised so let's not test for it in test 303
- We don't raise triggger 18 if we have a matching error, only on resubmission