### PR TITLE
Fix build docker image due to python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY ./package* /src/
 
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN apt-get update
-RUN apt-get install -y build-essential python gcc
+RUN apt-get install -y build-essential python3 gcc
 RUN npm i
 
 COPY ./features/ /src/features


### PR DESCRIPTION
Build docker image script was failing because python package has been renamed to python3.