### PR TITLE
Make basic login test check for triggers on the page, not PNC errors tab

### DIFF
--- a/features/basic-login.feature
+++ b/features/basic-login.feature
@@ -10,4 +10,5 @@ Feature: Basic end-to-end test
     When I view the list of exceptions
     Then the exception list should contain a record for "Rigout Dean"
     When I open the record for "Rigout Dean"
+      And I click the "Triggers" tab
     Then I see trigger "TRPR0010"

--- a/features/basic-login.feature
+++ b/features/basic-login.feature
@@ -6,7 +6,8 @@ Feature: Basic end-to-end test
   Scenario: Raising an exception message
     Given there is a valid record for "Rigout Dean" in the PNC
       And a message is received
-      And I am logged in as "exceptionhandler"
+      And I am logged in as "triggerhandler"
     When I view the list of exceptions
     Then the exception list should contain a record for "Rigout Dean"
-      And the record for "Rigout Dean" should not have any PNC errors
+    When I open the record for "Rigout Dean"
+    Then I see trigger "TRPR0010"

--- a/features/basic-login.feature
+++ b/features/basic-login.feature
@@ -3,7 +3,7 @@ Feature: Basic end-to-end test
   I want to make sure the message is displayed in the Bichard UI
 
   @NextUI
-  Scenario: Raising an exception message
+  Scenario: Log in to Bichard and view a case
     Given there is a valid record for "Rigout Dean" in the PNC
       And a message is received
       And I am logged in as "triggerhandler"


### PR DESCRIPTION
To support https://github.com/ministryofjustice/bichard7-next-ui/pull/328