### PR TITLE
Check exception unlocked event is generated

### DIFF
--- a/features/500-case-lock-events/test.feature
+++ b/features/500-case-lock-events/test.feature
@@ -12,4 +12,4 @@ Feature: {500} Lock and unlock events
 			And the audit log contains "Exception locked"
 		When I click the "Leave and unlock" button
 			Then the audit log contains "Trigger unlocked"
-			# And the audit log contains "Exception unlocked" //TODO: Uncomment this once nextUI supports exception handlers
+			And the audit log contains "Exception unlocked"

--- a/features/501-trigger-resolved-events/test.feature
+++ b/features/501-trigger-resolved-events/test.feature
@@ -21,4 +21,4 @@ Feature: {501} Trigger resolved events
 			And the audit log contains "Trigger locked"
 			And the audit log contains "Trigger marked as resolved by user"
 			And the audit log contains "All triggers marked as resolved"
-			# And the audit log contains "Trigger unlocked" //TODO: Uncomment when logic is implemented in the next UI
+			And the audit log contains "Trigger unlocked"


### PR DESCRIPTION
This was perviously disabled as it wasn't implemented in the new UI