### PR TITLE
Fix test behaviour for manually adding an offence in court

### DIFF
--- a/features/108-offence-start-date-mismatch/test.feature
+++ b/features/108-offence-start-date-mismatch/test.feature
@@ -32,9 +32,6 @@ Feature: {108} BR7 R5.0-RCD352-Offence Start Date mismatch
       And I view offence "1"
       And I correct "Sequence Number" to "1"
       And I click the "Offences" tab
-      And I view offence "4"
-      And I correct "Sequence Number" to "4"
-      And I click the "Offences" tab
       And I submit the record
     Then I see exception "(Submitted)" in the exception list table
       And the PNC updates the record

--- a/features/295-duplicate-offences-one-added-in-court/test.feature
+++ b/features/295-duplicate-offences-one-added-in-court/test.feature
@@ -34,9 +34,6 @@ Feature: {295} BR7-R5.9-RCD545-Duplicate Offences where 1 Offence is Added In Co
 			And I view offence "1"
 			And I correct "Sequence Number" to "1"
 			And I click the "Offences" tab
-			And I view offence "2"
-			And I correct "Sequence Number" to "2"
-			And I click the "Offences" tab
 			And I submit the record
 		Then I see exception "(Submitted)" in the exception list table
 			And the PNC updates the record

--- a/helpers/BrowserHelper.js
+++ b/helpers/BrowserHelper.js
@@ -16,7 +16,7 @@ class BrowserHelper {
     if (!this.browser)
       this.browser = await puppeteer.launch({
         ignoreHTTPSErrors: true,
-        headless: this.options.headless,
+        headless: this.options.headless ? "new" : false,
         args: [
           // Required for Docker version of Puppeteer
           "--no-sandbox",


### PR DESCRIPTION
Don't set the manual sequence number to a nonexistent sequence in the test - this used to work in Bichard but now we throw an exception since it doesn't exist!