### PR TITLE
Update ci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
         default: "true"
         type: string
     steps:
-      - run: bash scripts/fetch_docker_image.sh nodejs # required for message-forwarder in core
+      - run: bash scripts/fetch_docker_image.sh nodejs-20-2023 # required for message-forwarder in core
       - build_core_images
       - build_audit_logging_images
       - run:
@@ -100,7 +100,7 @@ commands:
 
   start_bichard7_core:
     steps:
-      - run: bash scripts/fetch_docker_image.sh nodejs # required for message-forwarder in core
+      - run: bash scripts/fetch_docker_image.sh nodejs-20-2023 # required for message-forwarder in core
       - build_core_images
       - build_audit_logging_images
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,9 @@ commands:
 
   start_bichard7_core:
     steps:
+      - run:
+          command: nvm install
+          working_directory: ~/bichard7-next-core
       - run: bash scripts/fetch_docker_image.sh nodejs-20-2023 # required for message-forwarder in core
       - build_core_images
       - build_audit_logging_images
@@ -179,7 +182,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/
-      - node/install
       - start_bichard7_core
       - run_test_chunk
       - save_artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ commands:
 jobs:
   build:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2204:2023.07.2
     resource_class: xlarge
     steps:
       - checkout
@@ -149,7 +149,7 @@ jobs:
 
   test-e2e-legacy:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2204:2023.07.2
       docker_layer_caching: false
     resource_class: large
     parallelism: 10
@@ -167,7 +167,7 @@ jobs:
 
   test-e2e-core:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2204:2023.07.2
       docker_layer_caching: false
     resource_class: large
     parallelism: 10
@@ -186,7 +186,7 @@ jobs:
 
   test-e2e-legacy-new-ui:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2204:2023.07.2
       docker_layer_caching: false
     resource_class: large
     parallelism: 10
@@ -205,7 +205,7 @@ jobs:
 
   test-characterisation-legacy:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2204:2023.07.2
       docker_layer_caching: false
     resource_class: large
     steps:
@@ -218,7 +218,7 @@ jobs:
 
   test-characterisation-core:
     machine:
-      image: ubuntu-2004:2022.07.1
+      image: ubuntu-2204:2023.07.2
       docker_layer_caching: false
     resource_class: large
     steps:


### PR DESCRIPTION
This PR updates CircleCI config to:
- Use the latest ubuntu machine image (ubuntu-2204:2023.07.2)
- Use our latest NodeJS image (required to build message-forwarder, event-handler, and audit-log-api images)
- Use nvm to install the NodeJS runtime version in Core repo