### PR TITLE
Make the tests less timing dependent

### DIFF
--- a/e2eTestBuildspec.yml
+++ b/e2eTestBuildspec.yml
@@ -21,7 +21,7 @@ phases:
       - echo "Build lock acquired"
       - export OLD_AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - export OLD_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-      - temp_role=$(aws sts assume-role --role-session-name "next" --role-arn "${ASSUME_ROLE_ARN}")
+      - temp_role=$(aws sts assume-role --role-session-name "next" --duration-seconds 10800 --role-arn "${ASSUME_ROLE_ARN}")
       - export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq -r .Credentials.AccessKeyId)
       - export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq -r .Credentials.SecretAccessKey)
       - export AWS_SESSION_TOKEN=$(echo $temp_role | jq -r .Credentials.SessionToken)

--- a/features/121-force-calculation-from-court-code/test.feature
+++ b/features/121-force-calculation-from-court-code/test.feature
@@ -16,7 +16,6 @@ Feature: {121} BR7 R5.1-RCD399-Force calculation-FF code in CourtHearingLocation
 
 	@Should
 	@PreProdTest
-	@OnlyRunsOnPNC
 	Scenario: Deriving the force owner from the court hearing location
 		When I am logged in as "met.police"
 			And "input-message" is received
@@ -30,8 +29,7 @@ Feature: {121} BR7 R5.1-RCD399-Force calculation-FF code in CourtHearingLocation
 		Then I see error "HO100206" in the "ASN" row of the results table
 		When I correct "ASN" to "1101VK0100000376269X"
 			And I submit the record
-		Then I see exception "(Submitted)" in the exception list table
-		When I reload until I don't see "(Submitted)"
+			And I reload until I don't see "(Submitted)"
 		Then I cannot see exception "HO100201" in the exception list table
 		When I am logged in as "met.police"
 			And I view the list of exceptions

--- a/features/142-trigger-reallocation/test.feature
+++ b/features/142-trigger-reallocation/test.feature
@@ -51,10 +51,9 @@ Feature: {142} BR7 R5.2-RCD423-Trigger Reallocation
       And I view offence "4"
       And I correct "Text" to "**Imprisonment for 12 Months with result text greater sixty fourEnd"
       And I submit the record
-    Then I see exception "(Submitted)" in the exception list table
-    When I reload until I don't see "(Submitted)"
+      And I reload until I don't see "(Submitted)"
       And I click the "Refresh" button
-      And I click the "Return To List (Unlock)" button
+      And I return to the list
     Then there are no exceptions or triggers
     When I am logged in as "norfolk.user"
       And I view the list of exceptions

--- a/features/158-breach-results/test.feature
+++ b/features/158-breach-results/test.feature
@@ -37,7 +37,7 @@ Feature: {158} BR7 R5.2.2-RCD518 - Result class Sentence & Adjournment Post Judg
 			And I view offence "2"
 			And I correct "Sequence Number" to "2"
 			And I submit the record
-			And I click the "Return To List" button
+			And I return to the list
 		Then I see trigger "PR06 - Imprisoned" in the exception list table
 			And I see exception "HO200113" in the exception list table
 		When I open the record for "DDDraven Alex"

--- a/features/190-correcting-invalid-asn/test.feature
+++ b/features/190-correcting-invalid-asn/test.feature
@@ -35,7 +35,7 @@ Feature: {190} R4.0_BR7_CC_TR_Offence Code Qualifiers
 			And I click the "Defendant" tab
 			And I correct "ASN" to "0901VK0100000342547V"
 			And I submit the record
-			And I click the "Return To List" button
+			And I return to the list
 		Then I see exception "HO100304" in the exception list table
 		When "input-message-2" is received
 		Then I see exception "HO100206" in the exception list table
@@ -44,6 +44,6 @@ Feature: {190} R4.0_BR7_CC_TR_Offence Code Qualifiers
 			And I click the "Defendant" tab
 			And I correct "ASN" to "0901VK0100000342547V"
 			And I submit the record
-			And I click the "Return To List" button
+			And I return to the list
 		Then I see exception "HO100304" in the exception list table
 			And the PNC record has not been updated

--- a/features/194-new-breach-offence-trigger-and-exception/test.feature
+++ b/features/194-new-breach-offence-trigger-and-exception/test.feature
@@ -31,9 +31,9 @@ Feature: {194} BR7-R5.4-RCD548-R5.3.2-RCD556-Breach Offence with Re-sentence for
 			And I click the "Offences" tab
 			And I view offence "1"
 		Then I see "3501" in the "CJS Code" row of the results table
-			And I click the "Return To List (Unlock)" button
+		When I return to the list
 			And I view the list of exceptions
-		When I open the record for "JUBES THETUBE"
+			And I open the record for "JUBES THETUBE"
 			And I click the "Triggers" tab
 		Then I see trigger "TRPR0006"
 			And I see trigger "TRPR0020" for offence "1"

--- a/features/264-aint-results/test.feature
+++ b/features/264-aint-results/test.feature
@@ -29,7 +29,7 @@ Feature: {264} BR7-R5.7-RCD603-AINT Result-Exception generation
 			And I click the "Defendant" tab
 			And I correct "Court PNCID" to "2013/0000016P"
 			And I submit the record
-			And I click the "Return To List" button
+			And I return to the list
 			And I reload until I don't see "(Submitted)"
 		Then the "record" for "EXCEPTIONAINT CASE" is "resolved"
 			And the "record" for "EXCEPTIONAINT CASE" is not "unresolved"

--- a/features/403-fix-exceptions/test.feature
+++ b/features/403-fix-exceptions/test.feature
@@ -18,8 +18,8 @@ Feature: 403 - Fixing exceptions and resubmitting
 			And I submit the record
 		Then I see exception "(Submitted)" in the exception list table
 		When I reload until I don't see "(Submitted)"
-      And I click the "Refresh" button
-      And I click the "Return To List (Unlock)" button
+			And I click the "Refresh" button
+			And I return to the list
 		Then the "record" for "Ladyfish Larry" is "resolved"
 			And the PNC updates the record
 			And there are no exceptions or triggers for this record

--- a/features/404-fix-exceptions-and-triggers/test.feature
+++ b/features/404-fix-exceptions-and-triggers/test.feature
@@ -20,7 +20,7 @@ Feature: 404 - Fixing exceptions and triggers and resubmitting
 		Then I see exception "(Submitted)" in the exception list table
 		When I reload until I don't see "(Submitted)"
 			And I click the "Refresh" button
-			And I click the "Return To List (Unlock)" button
+			And I return to the list
 		Then the "exception" for "SEXOFFENCE TRPRFOUR" is "resolved"
 			And the PNC updates the record
 		When I view the list of exceptions

--- a/features/405-fix-exceptions-multiple-attempts/test.feature
+++ b/features/405-fix-exceptions-multiple-attempts/test.feature
@@ -22,7 +22,7 @@ Feature: 405 - Fixing exceptions and resubmitting with multiple attempts
 			And I click the "Defendant" tab
 			And I correct "ASN" to "1101ZD0100000410804K"
 			And I submit the record
-			And I click the "Return To List" button
+			And I return to the list
 		Then the PNC updates the record
 			And the "record" for "Ladyfish Larry" is "resolved"
 			And there are no exceptions or triggers for this record

--- a/features/409-pnc-resubmission-errors/test.feature
+++ b/features/409-pnc-resubmission-errors/test.feature
@@ -32,5 +32,5 @@ Feature: {409} BR7-R5.7-RCD603-AINT Result-Exception generation
 			And I click the "Defendant" tab
 			And I correct "Court PNCID" to "2013/0000016P"
 			And I submit the record
-			And I click the "Return To List" button
+			And I return to the list
 		Then I see exception "HO100314" in the exception list table

--- a/scripts/run-pipeline-tests.sh
+++ b/scripts/run-pipeline-tests.sh
@@ -2,11 +2,18 @@
 
 set -xe
 
-if [ $WORKSPACE = "e2e-test" ]
+RUN_ALL_TESTS="${RUN_ALL_TESTS:-false}"
+
+if [ "$TRIGGER" == "application-semaphore" ]
+then
+  RUN_ALL_TESTS="true"
+fi
+
+if [ "$WORKSPACE" == "e2e-test" ]
 then
   echo "Build was triggered by $TRIGGER"
 
-  if [ $TRIGGER = "application-semaphore" ]
+  if [ $RUN_ALL_TESTS = "true" ]
   then
     echo "Running all tests (old UI)"
     CI=true RECORD=true MESSAGE_ENTRY_POINT=s3 npm run test
@@ -20,7 +27,7 @@ then
     echo "Running must tests (next UI)"
     CI=true RECORD=true MESSAGE_ENTRY_POINT=s3 npm run test:nextUI:must
   fi
-elif [ $WORKSPACE = "preprod" ]
+elif [ "$WORKSPACE" == "preprod" ]
 then
   echo "Running preprod tests (old UI)"
   CI=true RECORD=true MESSAGE_ENTRY_POINT=s3 npm run test:preprod

--- a/step-definitions/old-cucumber-js.steps.js
+++ b/step-definitions/old-cucumber-js.steps.js
@@ -86,7 +86,8 @@ const {
   checkNoExceptionsForThis,
   canSeeContentInTableForThis,
   switchBichard,
-  cannotSeeBichardSwitcher
+  cannotSeeBichardSwitcher,
+  returnToList
 } = require("./old-utils/ui");
 
 const {
@@ -131,6 +132,8 @@ When("I open the record for {string}", openRecordFor);
 When("I click the {string} menu button", clickMainTab);
 
 When("I click the {string} button", clickButton);
+
+When("I return to the list", returnToList);
 
 When("I submit the record", submitRecord);
 

--- a/step-definitions/old-utils/ui.js
+++ b/step-definitions/old-utils/ui.js
@@ -629,6 +629,18 @@ const cannotSeeBichardSwitcher = async function () {
   expect(bichardSwitcher.length).toEqual(0);
 };
 
+const returnToList = async function () {
+  const returnButton =
+    (await this.browser.page.$("[value='Return To List']")) ||
+    (await this.browser.page.$("[value='Return To List (Unlock)']")) ||
+    (await this.browser.page.$("[value='Return To List (Lock)']"));
+
+  if (!returnButton) {
+    throw new Error("Could not find return to list button");
+  }
+  await Promise.all([returnButton.click(), this.browser.page.waitForNavigation()]);
+};
+
 module.exports = {
   checkNoPncErrors,
   containsValue,
@@ -698,5 +710,6 @@ module.exports = {
   getRawTableData,
   recordsForPerson,
   switchBichard,
-  cannotSeeBichardSwitcher
+  cannotSeeBichardSwitcher,
+  returnToList
 };


### PR DESCRIPTION
- Adds a "When I return to the list" cucumber step because the return to list button changes depending on how long the backend takes to process data
- Enable the e2e tests in the pipeline to have an override for running all tests
- Make the role for running tests in CD last longer