### PR TITLE
Fix exception resolution tests that capturing incorrect behaviour

### DIFF
--- a/features/296-result-text-disposal-text/test.feature
+++ b/features/296-result-text-disposal-text/test.feature
@@ -22,7 +22,7 @@ Feature: {296} BR7-R5.9-RCD545-Duplicate Offences-DIFFERENT Result Text IS used 
 		Given the data for this test is in the PNC
 			And "input-message" is received
 
-	@Should @ExcludedOnNextUI
+	@Should @NextUI
 	Scenario: Ensure the result text is used as the PNC disposal text
 		Given I am logged in as "generalhandler"
 			And I view the list of exceptions
@@ -36,29 +36,6 @@ Feature: {296} BR7-R5.9-RCD545-Duplicate Offences-DIFFERENT Result Text IS used 
 			And I match the offence to PNC offence "2"
 			And I submit the record
 		Then I see exception "(Submitted)" in the exception list table
-			And the PNC updates the record
-		When I reload until I see "PS03 - Disposal text truncated"
-			And I open the record for "RESULTTEXTISUSED DUPLICATEOFFENCES"
-			And I click the "Triggers" tab
-		Then I see trigger "TRPR0003" for offence "1"
-			And I see trigger "TRPR0003" for offence "2"
-			And I see trigger "TRPS0003" for offence "1"
-			And I see trigger "TRPS0003" for offence "2"
-
-	@Should @NextUI @ExcludeOnLegacyUI
-	Scenario: Ensure the result text is used as the PNC disposal text NextUI
-		Given I am logged in as "generalhandler"
-			And I view the list of exceptions
-		Then I see exception "HO100310 (2)" in the exception list table
-		When I open the record for "RESULTTEXTISUSED DUPLICATEOFFENCES"
-			And I click the "Offences" tab
-			And I view offence "1"
-			And I match the offence to PNC offence "1"
-			And I return to the offence list
-			And I view offence "2"
-			And I match the offence to PNC offence "2"
-			And I submit the record
-		Then I see exception "(Resolved)" in the exception list table
 			And the PNC updates the record
 		When I reload until I see "PS03 - Disposal text truncated"
 			And I open the record for "RESULTTEXTISUSED DUPLICATEOFFENCES"

--- a/features/410-blank-manual-seq-added-in-court/test.feature
+++ b/features/410-blank-manual-seq-added-in-court/test.feature
@@ -9,7 +9,7 @@ Feature: {410} Leaving Manual Sequence Number blank to make an offence Added in 
 		Given the data for this test is in the PNC
 			And "input-message" is received
 
-	@Should @ExcludedOnNextUI
+	@Should @NextUI
 	Scenario: Leaving Manual Sequence Number blank to make an offence Added in Court
 		Given I am logged in as "generalhandler"
 			And I view the list of exceptions
@@ -23,20 +23,4 @@ Feature: {410} Leaving Manual Sequence Number blank to make an offence Added in 
 			And I match the offence as Added In Court
 			And I submit the record
 		Then I see exception "(Submitted)" in the exception list table
-			And the PNC updates the record
-
-	@Should @NextUI @ExcludeOnLegacyUI
-	Scenario: Leaving Manual Sequence Number blank to make an offence Added in Court NextUI
-		Given I am logged in as "generalhandler"
-			And I view the list of exceptions
-		Then I see exception "HO100310 (2)" in the exception list table
-		When I open the record for "RESULTTEXTISUSED DUPLICATEOFFENCEADDEDINCOURT"
-			And I click the "Offences" tab
-			And I view offence "1"
-			And I match the offence to PNC offence "1"
-			And I return to the offence list
-			And I view offence "2"
-			And I match the offence as Added In Court
-			And I submit the record
-		Then I see exception "(Resolved)" in the exception list table
 			And the PNC updates the record

--- a/features/411-blank-manual-seq-match/test.feature
+++ b/features/411-blank-manual-seq-match/test.feature
@@ -9,7 +9,7 @@ Feature: {411} Leaving Manual Sequence Number blank to make it match the remaini
 		Given the data for this test is in the PNC
 			And "input-message" is received
 
-	@Should @ExcludedOnNextUI
+	@Should @NextUI
 	Scenario: Leaving Manual Sequence Number blank to make it match the remaining offence on PNC
 		Given I am logged in as "generalhandler"
 			And I view the list of exceptions
@@ -23,20 +23,4 @@ Feature: {411} Leaving Manual Sequence Number blank to make it match the remaini
 			And I match the offence as Added In Court
 			And I submit the record
 		Then I see exception "(Submitted)" in the exception list table
-			And the PNC updates the record
-
-	@Should @NextUI @ExcludeOnLegacyUI
-	Scenario: Leaving Manual Sequence Number blank to make it match the remaining offence on PNC NextUI
-		Given I am logged in as "generalhandler"
-			And I view the list of exceptions
-		Then I see exception "HO100310 (2)" in the exception list table
-		When I open the record for "RESULTTEXTISUSED DUPLICATEOFFENCEADDEDINCOURT"
-			And I click the "Offences" tab
-			And I view offence "1"
-			And I match the offence to PNC offence "1"
-			And I return to the offence list
-			And I view offence "2"
-			And I match the offence as Added In Court
-			And I submit the record
-		Then I see exception "(Resolved)" in the exception list table
 			And the PNC updates the record

--- a/features/504-note-generation/test.feature
+++ b/features/504-note-generation/test.feature
@@ -9,7 +9,7 @@ Feature: {504} Note generation
     Given the data for this test is in the PNC
       And "input-message" is received
 
-  @ExcludedOnNextUI
+  @NextUI
   Scenario: PNC is updated when there are multiple identical results NextUI
     Given I am logged in as "generalhandler"
       And I view the list of exceptions
@@ -26,34 +26,6 @@ Feature: {504} Note generation
       And I match the offence as Added In Court
       And I submit the record
     Then I see exception "(Submitted)" in the exception list table
-      And the PNC updates the record
-    When I reload until I see "PS10 - Offence added to PNC"
-      And I open the record for "MISMATCH OFFENCE"
-      And I click the "Notes" tab
-    Then I see "Error codes: 2 x HO100310" in the table
-      And I see "Trigger codes: 1 x TRPR0004" in the table
-      And I see "generalhandler: Portal Action: Resubmitted Message." in the table
-      And I see "generalhandler: Portal Action: Update Applied. Element: OffenceReasonSequence. New Value: 1" in the table
-      And I see "Triggers added: 1 x TRPR0018" in the table
-      And I see "Triggers added: 2 x TRPS0010" in the table
-
-  @NextUI @ExcludeOnLegacyUI
-  Scenario: PNC is updated when there are multiple identical results NextUI
-    Given I am logged in as "generalhandler"
-      And I view the list of exceptions
-    Then I see trigger "HO100310 (2)" in the exception list table
-    When I open the record for "MISMATCH OFFENCE"
-      And I click the "Notes" tab
-    Then I see "Error codes: 2 x HO100310" in the table
-      And I see "Trigger codes: 1 x TRPR0004" in the table
-    When I click the "Offences" tab
-      And I view offence "1"
-      And I match the offence to PNC offence "1"
-      And I return to the offence list
-      And I view offence "3"
-      And I match the offence as Added In Court
-      And I submit the record
-    Then I see exception "(Resolved)" in the exception list table
       And the PNC updates the record
     When I reload until I see "PS10 - Offence added to PNC"
       And I open the record for "MISMATCH OFFENCE"


### PR DESCRIPTION
### Context

When exceptions are resolved in the new UI, the case incorrectly has a RESOLVED badge, even when the case has unresolved triggers.

### Changes
- Remove incorrect scenarios 
- Enable tests for new UI that are running on a legacy application