### PR TITLE
Remove cucumber step that check submitted status

### DIFF
--- a/features/296-result-text-disposal-text/test.feature
+++ b/features/296-result-text-disposal-text/test.feature
@@ -35,8 +35,7 @@ Feature: {296} BR7-R5.9-RCD545-Duplicate Offences-DIFFERENT Result Text IS used 
 			And I view offence "2"
 			And I match the offence to PNC offence "2"
 			And I submit the record
-		Then I see exception "(Submitted)" in the exception list table
-			And the PNC updates the record
+		Then the PNC updates the record
 		When I reload until I see "PS03 - Disposal text truncated"
 			And I open the record for "RESULTTEXTISUSED DUPLICATEOFFENCES"
 			And I click the "Triggers" tab

--- a/features/410-blank-manual-seq-added-in-court/test.feature
+++ b/features/410-blank-manual-seq-added-in-court/test.feature
@@ -22,5 +22,4 @@ Feature: {410} Leaving Manual Sequence Number blank to make an offence Added in 
 			And I view offence "2"
 			And I match the offence as Added In Court
 			And I submit the record
-		Then I see exception "(Submitted)" in the exception list table
-			And the PNC updates the record
+		Then the PNC updates the record

--- a/features/411-blank-manual-seq-match/test.feature
+++ b/features/411-blank-manual-seq-match/test.feature
@@ -22,5 +22,4 @@ Feature: {411} Leaving Manual Sequence Number blank to make it match the remaini
 			And I view offence "2"
 			And I match the offence as Added In Court
 			And I submit the record
-		Then I see exception "(Submitted)" in the exception list table
-			And the PNC updates the record
+		Then the PNC updates the record

--- a/features/504-note-generation/test.feature
+++ b/features/504-note-generation/test.feature
@@ -25,8 +25,7 @@ Feature: {504} Note generation
       And I view offence "3"
       And I match the offence as Added In Court
       And I submit the record
-    Then I see exception "(Submitted)" in the exception list table
-      And the PNC updates the record
+    Then the PNC updates the record
     When I reload until I see "PS10 - Offence added to PNC"
       And I open the record for "MISMATCH OFFENCE"
       And I click the "Notes" tab


### PR DESCRIPTION
This causes flaky tests on the new UI because Bichard may pick up and update the case status before the test navigates to the case list and checks the status.