### PR TITLE
Add phase parameter for processing messages in characterisation tests

### DIFF
--- a/characterisation/helpers/processMessage.ts
+++ b/characterisation/helpers/processMessage.ts
@@ -2,6 +2,7 @@ import BichardResultType from "../types/BichardResultType";
 import { ResultedCaseMessageParsedXml } from "../types/IncomingMessage";
 import processMessageBichard from "./processMessageBichard";
 import processMessageCore from "./processMessageCore";
+import Phase from "../types/Phase";
 
 export type ProcessMessageOptions = {
   expectRecord?: boolean;
@@ -11,6 +12,7 @@ export type ProcessMessageOptions = {
   pncOverrides?: Partial<ResultedCaseMessageParsedXml>;
   pncMessage?: string;
   pncAdjudication?: boolean;
+  phase?: Phase;
 };
 
 export default (messageXml: string, options: ProcessMessageOptions = {}): Promise<BichardResultType> => {

--- a/characterisation/helpers/processMessageCore.ts
+++ b/characterisation/helpers/processMessageCore.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import BichardResultType from "../types/BichardResultType";
 import generateMockPncQueryResult from "./generateMockPncQueryResult";
 import { ProcessMessageOptions } from "./processMessage";
+import Phase from "../types/Phase";
 
 const processMessageCore = async (
   messageXml: string,
@@ -10,17 +11,19 @@ const processMessageCore = async (
     pncOverrides = {},
     pncCaseType = "court",
     pncMessage,
-    pncAdjudication = false
+    pncAdjudication = false,
+    phase = Phase.HEARING_OUTCOME
   }: ProcessMessageOptions
 ): Promise<BichardResultType> => {
   const pncQueryResult = recordable
     ? generateMockPncQueryResult(pncMessage ? pncMessage : messageXml, pncOverrides, pncCaseType, pncAdjudication)
     : undefined;
-  const query = {
+  const requestBody = {
     inputMessage: messageXml,
-    pncQueryResult
+    pncQueryResult,
+    phase
   };
-  const result = await axios.post<BichardResultType>("http://localhost:6000/", query);
+  const result = await axios.post<BichardResultType>("http://localhost:6000/", requestBody);
   return result.data;
 };
 

--- a/characterisation/types/Phase.ts
+++ b/characterisation/types/Phase.ts
@@ -1,0 +1,6 @@
+enum Phase {
+  HEARING_OUTCOME = 1,
+  PNC_UPDATE = 2
+}
+
+export default Phase


### PR DESCRIPTION
## Content

Now that we've rewritten Phase 2, we want to enable characterisation tests for it.

## Changes proposed to this PR

- Add `phase` parameter in the `processMessage` functions for Bichard and Core.
  - It defaults to Phase 1.
  - For Bichard: send the message to the `HEARING_OUTCOME_PNC_UPDATE_QUEUE` queue if Phase 2 instead of `COURT_RESULT_INPUT_QUEUE`. I took the queue name from the [send to Phase 2 Conductor task](https://github.com/ministryofjustice/bichard7-next-core/blob/b6e2066d1584fa9e5d35a06c5b2ce38c2035e032/packages/core/conductor-tasks/bichard_phase_1/sendToPhase2.ts#L23), correct me if this isn't the right one!
  - For Core: add the phase to POST request to test server API for Core.

## Next steps

- Update test server in Core to use the `phase` and return Phase 2 result as well.

https://dsdmoj.atlassian.net/browse/BICAWS7-3017