### PR TITLE
Phase2 core tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,16 +37,11 @@ commands:
           command: make build-api-server build-event-handler-server
 
   run_test_chunk:
-    parameters:
-      NEXTUI:
-        default: "false"
-        type: "string"
     steps:
       - run:
           name: Run test chunk
           command: |
             CHUNK=$(circleci tests glob "features/**/*.feature" | circleci tests split --split-by=timings) \
-            NEXTUI=<<parameters.NEXTUI>> \
             npm run test:chunk
 
   save_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,133 +151,41 @@ jobs:
           root: ~/
           paths: .
 
-  test-e2e-legacy:
+  test-e2e:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
     resource_class: large
     parallelism: 10
+    parameters:
+      nextUi:
+        type: boolean
+      phase2CoreCanaryRatio:
+        type: string
+      messageEntryPoint:
+        type: string
     environment:
       RECORD: "true"
-      MESSAGE_ENTRY_POINT: mq
       AWS_URL: "http://localhost:4566"
+      MESSAGE_ENTRY_POINT: << parameters.messageEntryPoint >>
+      NEXTUI: << parameters.nextUi >>
+      PHASE2_CORE_CANARY_RATIO: << parameters.phase2CoreCanaryRatio >>
     steps:
       - attach_workspace:
           at: ~/
       - set_locale
       - node_install
-      - start_bichard7_legacy
+      - when:
+          condition:
+            equal: [ "mq", << parameters.messageEntryPoint >> ]
+          steps:
+            - start_bichard7_legacy
+      - when:
+          condition:
+            equal: [ "s3", << parameters.messageEntryPoint >> ]
+          steps:
+          - start_bichard7_core
       - run_test_chunk
-      - save_artifacts
-      - store_test_results:
-          path: ./cucumber/results
-
-  test-e2e-legacy-new-ui:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: false
-    resource_class: large
-    parallelism: 10
-    environment:
-      RECORD: "true"
-      MESSAGE_ENTRY_POINT: mq
-      AWS_URL: "http://localhost:4566"
-    steps:
-      - attach_workspace:
-          at: ~/
-      - set_locale
-      - node_install
-      - start_bichard7_legacy
-      - run_test_chunk:
-          NEXTUI: "true"
-      - save_artifacts
-      - store_test_results:
-          path: ./cucumber/results
-
-  test-e2e-core:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: false
-    resource_class: large
-    parallelism: 10
-    environment:
-      RECORD: "true"
-      MESSAGE_ENTRY_POINT: s3
-      AWS_URL: "http://localhost:4566"
-    steps:
-      - attach_workspace:
-          at: ~/
-      - set_locale
-      - node_install
-      - start_bichard7_core
-      - run_test_chunk
-      - save_artifacts
-      - store_test_results:
-          path: ./cucumber/results
-
-  test-e2e-core-new-ui:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: false
-    resource_class: large
-    parallelism: 10
-    environment:
-      RECORD: "true"
-      MESSAGE_ENTRY_POINT: s3
-      AWS_URL: "http://localhost:4566"
-    steps:
-      - attach_workspace:
-          at: ~/
-      - set_locale
-      - node_install
-      - start_bichard7_core
-      - run_test_chunk:
-          NEXTUI: "true"
-      - save_artifacts
-      - store_test_results:
-          path: ./cucumber/results
-
-  test-e2e-phase2-core:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: false
-    resource_class: large
-    parallelism: 10
-    environment:
-      RECORD: "true"
-      MESSAGE_ENTRY_POINT: s3
-      AWS_URL: "http://localhost:4566"
-      PHASE2_CORE_CANARY_RATIO: "1.0"
-    steps:
-      - attach_workspace:
-          at: ~/
-      - set_locale
-      - node_install
-      - start_bichard7_core
-      - run_test_chunk
-      - save_artifacts
-      - store_test_results:
-          path: ./cucumber/results
-
-  test-e2e-phase2-core-new-ui:
-    machine:
-      image: ubuntu-2204:current
-      docker_layer_caching: false
-    resource_class: large
-    parallelism: 10
-    environment:
-      RECORD: "true"
-      MESSAGE_ENTRY_POINT: s3
-      AWS_URL: "http://localhost:4566"
-      PHASE2_CORE_CANARY_RATIO: "1.0"
-    steps:
-      - attach_workspace:
-          at: ~/
-      - set_locale
-      - node_install
-      - start_bichard7_core
-      - run_test_chunk:
-          NEXTUI: "true"
       - save_artifacts
       - store_test_results:
           path: ./cucumber/results
@@ -315,22 +223,46 @@ workflows:
   deploy:
     jobs:
       - build
-      - test-e2e-legacy:
+      - test-e2e:
+          name: test-e2e-legacy
+          nextUi: false
+          phase2CoreCanaryRatio: "0.0"
+          messageEntryPoint: mq
           requires:
             - build
-      - test-e2e-legacy-new-ui:
+      - test-e2e:
+          name: test-e2e-legacy-new-ui
+          nextUi: true
+          phase2CoreCanaryRatio: "0.0"
+          messageEntryPoint: mq
           requires:
             - build
-      - test-e2e-core:
+      - test-e2e:
+          name: test-e2e-core
+          nextUi: false
+          phase2CoreCanaryRatio: "0.0"
+          messageEntryPoint: s3
           requires:
             - build
-      - test-e2e-core-new-ui:
+      - test-e2e:
+          name: test-e2e-core-new-ui
+          nextUi: true
+          phase2CoreCanaryRatio: "0.0"
+          messageEntryPoint: s3
           requires:
             - build
-      - test-e2e-phase2-core:
+      - test-e2e:
+          name: test-e2e-phase2-core
+          nextUi: false
+          phase2CoreCanaryRatio: "1.0"
+          messageEntryPoint: s3
           requires:
             - build
-      - test-e2e-phase2-core-new-ui:
+      - test-e2e:
+          name: test-e2e-phase2-core-new-ui
+          nextUi: true
+          phase2CoreCanaryRatio: "1.0"
+          messageEntryPoint: s3
           requires:
             - build
       - test-characterisation-legacy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,6 +237,51 @@ jobs:
       - store_test_results:
           path: ./cucumber/results
 
+  test-e2e-phase2-core:
+    machine:
+      image: ubuntu-2204:current
+      docker_layer_caching: false
+    resource_class: large
+    parallelism: 10
+    environment:
+      RECORD: "true"
+      MESSAGE_ENTRY_POINT: s3
+      AWS_URL: "http://localhost:4566"
+      PHASE2_CORE_CANARY_RATIO: "1.0"
+    steps:
+      - attach_workspace:
+          at: ~/
+      - set_locale
+      - node_install
+      - start_bichard7_core
+      - run_test_chunk
+      - save_artifacts
+      - store_test_results:
+          path: ./cucumber/results
+
+  test-e2e-phase2-core-new-ui:
+    machine:
+      image: ubuntu-2204:current
+      docker_layer_caching: false
+    resource_class: large
+    parallelism: 10
+    environment:
+      RECORD: "true"
+      MESSAGE_ENTRY_POINT: s3
+      AWS_URL: "http://localhost:4566"
+      PHASE2_CORE_CANARY_RATIO: "1.0"
+    steps:
+      - attach_workspace:
+          at: ~/
+      - set_locale
+      - node_install
+      - start_bichard7_core
+      - run_test_chunk:
+          NEXTUI: "true"
+      - save_artifacts
+      - store_test_results:
+          path: ./cucumber/results
+
   test-characterisation-legacy:
     machine:
       image: ubuntu-2204:current
@@ -280,6 +325,12 @@ workflows:
           requires:
             - build
       - test-e2e-core-new-ui:
+          requires:
+            - build
+      - test-e2e-phase2-core:
+          requires:
+            - build
+      - test-e2e-phase2-core-new-ui:
           requires:
             - build
       - test-characterisation-legacy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,8 +154,7 @@ jobs:
     parallelism: 10
     parameters:
       nextUi:
-        type: enum
-        enum: ["true", "false"]
+        type: boolean
       phase2CoreCanaryRatio:
         type: enum
         enum: ["1.0", "0.0"]
@@ -223,42 +222,42 @@ workflows:
       - build
       - test-e2e:
           name: test-e2e-legacy
-          nextUi: "false"
+          nextUi: false
           phase2CoreCanaryRatio: "0.0"
           messageEntryPoint: mq
           requires:
             - build
       - test-e2e:
           name: test-e2e-legacy-new-ui
-          nextUi: "true"
+          nextUi: true
           phase2CoreCanaryRatio: "0.0"
           messageEntryPoint: mq
           requires:
             - build
       - test-e2e:
           name: test-e2e-core
-          nextUi: "false"
+          nextUi: false
           phase2CoreCanaryRatio: "0.0"
           messageEntryPoint: s3
           requires:
             - build
       - test-e2e:
           name: test-e2e-core-new-ui
-          nextUi: "true"
+          nextUi: true
           phase2CoreCanaryRatio: "0.0"
           messageEntryPoint: s3
           requires:
             - build
       - test-e2e:
           name: test-e2e-phase2-core
-          nextUi: "false"
+          nextUi: false
           phase2CoreCanaryRatio: "1.0"
           messageEntryPoint: s3
           requires:
             - build
       - test-e2e:
           name: test-e2e-phase2-core-new-ui
-          nextUi: "true"
+          nextUi: true
           phase2CoreCanaryRatio: "1.0"
           messageEntryPoint: s3
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,11 +159,14 @@ jobs:
     parallelism: 10
     parameters:
       nextUi:
-        type: boolean
+        type: enum
+        enum: ["true", "false"]
       phase2CoreCanaryRatio:
-        type: string
+        type: enum
+        enum: ["1.0", "0.0"]
       messageEntryPoint:
-        type: string
+        type: enum
+        enum: ["mq", "s3"]
     environment:
       RECORD: "true"
       AWS_URL: "http://localhost:4566"
@@ -225,42 +228,42 @@ workflows:
       - build
       - test-e2e:
           name: test-e2e-legacy
-          nextUi: false
+          nextUi: "false"
           phase2CoreCanaryRatio: "0.0"
           messageEntryPoint: mq
           requires:
             - build
       - test-e2e:
           name: test-e2e-legacy-new-ui
-          nextUi: true
+          nextUi: "true"
           phase2CoreCanaryRatio: "0.0"
           messageEntryPoint: mq
           requires:
             - build
       - test-e2e:
           name: test-e2e-core
-          nextUi: false
+          nextUi: "false"
           phase2CoreCanaryRatio: "0.0"
           messageEntryPoint: s3
           requires:
             - build
       - test-e2e:
           name: test-e2e-core-new-ui
-          nextUi: true
+          nextUi: "true"
           phase2CoreCanaryRatio: "0.0"
           messageEntryPoint: s3
           requires:
             - build
       - test-e2e:
           name: test-e2e-phase2-core
-          nextUi: false
+          nextUi: "false"
           phase2CoreCanaryRatio: "1.0"
           messageEntryPoint: s3
           requires:
             - build
       - test-e2e:
           name: test-e2e-phase2-core-new-ui
-          nextUi: true
+          nextUi: "true"
           phase2CoreCanaryRatio: "1.0"
           messageEntryPoint: s3
           requires:

--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ screenshots/
 loadtest/config.json
 
 comparisons
+
+# Ignore cumcumber test results
+cucumber/

--- a/features/001-sexual-offences/test.feature
+++ b/features/001-sexual-offences/test.feature
@@ -20,6 +20,7 @@ Feature: {001} R3_BR7_TR_003_TRPR0004
 
 	@Should
 	@NextUI
+	@Phase2Core
 	Scenario: Updates and triggers are correctly generated for sexual offences
 		Given I am logged in as "supervisor"
 			And I view the list of exceptions

--- a/features/006-judgement-final-result/test.feature
+++ b/features/006-judgement-final-result/test.feature
@@ -20,6 +20,7 @@ Feature: {006} R3_BR7_TR_003_TRPS0002
 
 	@Should
 	@NextUI
+	@Phase2Core
 	Scenario: I can resolve a trigger for check address
 		Given I am logged in as "supervisor"
 		When I view the list of exceptions

--- a/features/010a-nppa-exceptions/test.feature
+++ b/features/010a-nppa-exceptions/test.feature
@@ -15,7 +15,7 @@ Feature: {010} R2_Regression_NPPA_NPP_001 - part 1
 	Background:
 		Given "input-message" is received
 
-	@Could @NextUI
+	@Could @NextUI @Phase2Core
 	Scenario: NPPA exception generation
 		Given I am logged in as "herts.user"
 			And I view the list of exceptions

--- a/features/010b-nppa-ignored-results/test.feature
+++ b/features/010b-nppa-ignored-results/test.feature
@@ -18,6 +18,7 @@ Feature: {010} R2_Regression_NPPA_NPP_001 - part 2
 	@Could
 	@AuditLog
 	@NextUI
+	@Phase2Core
 	Scenario: NPPA exception generation
 		Given I am logged in as "wilt.shire"
 			And I view the list of exceptions

--- a/features/011a-nppa-redirection/test.feature
+++ b/features/011a-nppa-redirection/test.feature
@@ -18,7 +18,7 @@ Feature: {011} R2_Regression_NPPA_PP_002 - part 1
 	Background:
 		Given "input-message" is received
 
-	@Could @NextUI
+	@Could @NextUI @Phase2Core
 	Scenario: NPPA exception generation and case redirection
 		Given I am logged in as "met.police"
 			And I view the list of exceptions

--- a/features/011b-nppa-ignored-results/test.feature
+++ b/features/011b-nppa-ignored-results/test.feature
@@ -20,6 +20,7 @@ Feature: {011} R2_Regression_NPPA_PP_002 - part 2
 
 	@Could
 	@AuditLog
+	@Phase2Core
 	Scenario: Ignored results
 		Given I am logged in as "met.police"
 			And I view the list of exceptions

--- a/features/013-extra-offence-on-pnc/test.feature
+++ b/features/013-extra-offence-on-pnc/test.feature
@@ -20,7 +20,7 @@ Feature: {013} R3_BR7_EX_001_Extra Offence on PNC
 
   @Must
   @Parallel
-	@Phase2Core
+  @Phase2Core
   Scenario: Exception is raised when there is a data mismatch
     Given I am logged in as "supervisor"
       And I view the list of exceptions

--- a/features/013-extra-offence-on-pnc/test.feature
+++ b/features/013-extra-offence-on-pnc/test.feature
@@ -20,6 +20,7 @@ Feature: {013} R3_BR7_EX_001_Extra Offence on PNC
 
   @Must
   @Parallel
+	@Phase2Core
   Scenario: Exception is raised when there is a data mismatch
     Given I am logged in as "supervisor"
       And I view the list of exceptions

--- a/features/014-no-offences-match/test.feature
+++ b/features/014-no-offences-match/test.feature
@@ -20,6 +20,7 @@ Feature: {014} R3_BR7_EX_001a_No Offences Match
 			And "input-message" is received
 
 	@Should
+	@Phase2Core
 	Scenario: Test that PNC detects a mismatch on offences and they can be manually resolved
 		Given I am logged in as "supervisor"
 			And I view the list of exceptions

--- a/features/018-results-already-on-pnc/test.feature
+++ b/features/018-results-already-on-pnc/test.feature
@@ -23,6 +23,7 @@ Feature: {018} R3_BR7_NX001_Results Already on PNC
 	@Could
 	@ExcludedOnConductor
 	@NextUI
+	@Phase2Core
 	Scenario: Handling results when they are already on the PNC
 		Given "input-message-1" is received
 			And I am logged in as "generalhandler"

--- a/features/019-identical_results_update/test.feature
+++ b/features/019-identical_results_update/test.feature
@@ -21,6 +21,7 @@ Feature: {019} R3_BR7_PU_005_Identical Results Update
   @Must
   @Parallel
   @NextUI
+  @Phase2Core
   Scenario: PNC is updated when there are multiple identical results
     Given I am logged in as "supervisor"
       And I view the list of exceptions

--- a/features/021-mismatch-between-offences/test.feature
+++ b/features/021-mismatch-between-offences/test.feature
@@ -24,6 +24,7 @@ Feature: {021} R3_BR7_SC_001_Mismatch Between Offences_Adjournment with Judgemen
 
   @Must
   @Parallel
+	@Phase2Core
   Scenario: Exception is raised when there is a data mismatch
     Given I am logged in as "generalhandler"
       And I view the list of exceptions

--- a/features/021-mismatch-between-offences/test.feature
+++ b/features/021-mismatch-between-offences/test.feature
@@ -24,7 +24,7 @@ Feature: {021} R3_BR7_SC_001_Mismatch Between Offences_Adjournment with Judgemen
 
   @Must
   @Parallel
-	@Phase2Core
+  @Phase2Core
   Scenario: Exception is raised when there is a data mismatch
     Given I am logged in as "generalhandler"
       And I view the list of exceptions

--- a/features/032-offences-taken-into-consideration/test.feature
+++ b/features/032-offences-taken-into-consideration/test.feature
@@ -18,7 +18,7 @@ Feature: {032} 3.2 UAT - TIC Change
 		Given the data for this test is in the PNC
 			And "input-message" is received
 
-	@Should @NextUI
+	@Should @NextUI @Phase2Core
 	Scenario: Offences Taken Into Consideration update PNC and raise a trigger
 		Given I am logged in as "supervisor"
 			And I view the list of exceptions

--- a/features/033-sine-die-results/test.feature
+++ b/features/033-sine-die-results/test.feature
@@ -17,7 +17,7 @@ Feature: {033} R3.3_BR7_Sine Die_Add Result Code 3027
 	Background:
 		Given the data for this test is in the PNC
 
-	@Could @NextUI
+	@Could @NextUI @Phase2Core
 	Scenario: Correctly handling Sine Die results
 		Given I am logged in as "supervisor"
 		When "input-message-1" is received

--- a/features/034a-valid-asn-format/test.feature
+++ b/features/034a-valid-asn-format/test.feature
@@ -21,6 +21,7 @@ Feature: {034} R3.3_BR7_SPI ASN Validation - 1
 
 	@Should
 	@NextUI
+	@Phase2Core
 	Scenario: Validating correct ASN format
 		Given I am logged in as "supervisor"
 			And I view the list of exceptions

--- a/features/034b-valid-asn-format/test.feature
+++ b/features/034b-valid-asn-format/test.feature
@@ -21,6 +21,7 @@ Feature: {034} R3.3_BR7_SPI ASN Validation - 2
 
 	@Should
 	@NextUI
+	@Phase2Core
 	Scenario: Validating correct ASN format
 		Given I am logged in as "supervisor"
 			And I view the list of exceptions

--- a/features/035-offence-category/test.feature
+++ b/features/035-offence-category/test.feature
@@ -16,6 +16,7 @@ Feature: {035} R3.3_BR7_Remove HO Exception for No Results
 		Given "input-message" is received
 
 	@Should
+	@Phase2Core
 	Scenario: No exceptions and triggers are created, nor is PNC called
 		Given I am logged in as "generalhandler"
 			And I view the list of exceptions

--- a/features/036-penalty-points/test.feature
+++ b/features/036-penalty-points/test.feature
@@ -19,6 +19,7 @@ Feature: {036} 3.3_BR7_Penalty Points for Result Code 3008
 
 	@Could
 	@NextUI
+	@Phase2Core
 	Scenario: Hearing results with penalty points are sent to the PNC
 		Given I am logged in as "supervisor"
 			And I view the list of exceptions

--- a/features/040-user-performance-report/test.feature
+++ b/features/040-user-performance-report/test.feature
@@ -19,6 +19,7 @@ Feature: {040} 04 MIS - User Performance Summary
 
 	@Could
 	@ExcludeOnPreProd
+	@Phase2Core
 	Scenario: Generating the user performance report
 		Given I am logged in as "generalhandler"
 			And I view the list of exceptions

--- a/features/041-trigger-report/test.feature
+++ b/features/041-trigger-report/test.feature
@@ -18,6 +18,7 @@ Feature: {041} R3.3_BR7_Operational Trigger Report
 	@Could
 	@ExcludeOnPreProd
 	@ExcludedOnConductor
+	@Phase2Core
 	Scenario: Generating the operational trigger report
 		Given "input-message-1" is received
 			And "input-message-2" is received

--- a/features/044-fta-undated-warrant/test.feature
+++ b/features/044-fta-undated-warrant/test.feature
@@ -20,6 +20,7 @@ Feature: {044} #151 - FTA Undated Warrant
 
 	@Could
 	@NextUI
+	@Phase2Core
 	Scenario: Handling FTA results with undated warrant
 		Given I am logged in as "supervisor"
 			And I view the list of exceptions

--- a/features/047-result-text-population/test.feature
+++ b/features/047-result-text-population/test.feature
@@ -20,6 +20,7 @@ Feature: {047} #186 - Result text population for Orders - 2nd variation
 
 	@Could
 	@NextUI
+	@Phase2Core
 	Scenario: Result text population for Orders - 2nd variation
 		Given I am logged in as "supervisor"
 		When I view the list of exceptions

--- a/features/049-curfew-orders/test.feature
+++ b/features/049-curfew-orders/test.feature
@@ -27,6 +27,7 @@ Feature: {049} #191 - TRPS0008 Required for curfew orders (1052) NOT TRPR0003
 			And "input-message" is received
 
 	@Should
+	@Phase2Core
 	Scenario: Ensure that a trigger is raised on Electronic Tagging and the qualifier is in the correct table
 		Given I am logged in as "supervisor"
 		When I view the list of exceptions

--- a/features/050-yz-force/test.feature
+++ b/features/050-yz-force/test.feature
@@ -19,7 +19,7 @@ Feature: {050} R3.4_BR7_YZ Force Code
     Given the data for this test is in the PNC
       And "input-message" is received
 
-  @Must @NextUI
+  @Must @NextUI @Phase2Core
   Scenario: YZ Force code is used in logs
     Given I am logged in as "generalhandler"
       And I view the list of exceptions

--- a/features/054-duration-unit-session/test.feature
+++ b/features/054-duration-unit-session/test.feature
@@ -19,6 +19,7 @@ Feature: {054} R3.4_BR7_Duration Unit_Session
 
 	@Could
 	@NextUI
+	@Phase2Core
 	Scenario: Handling messages with session duration
 		Given I am logged in as "supervisor"
 			And I view the list of exceptions

--- a/features/057-judgement-with-final-result/test.feature
+++ b/features/057-judgement-with-final-result/test.feature
@@ -18,7 +18,7 @@ Feature: {057} #192 - Result Date
 		Given the data for this test is in the PNC
 			And "input-message" is received
 
-	@Could @NextUI
+	@Could @NextUI @Phase2Core
 	Scenario: Validating judgement with final result automation
 		Given I am logged in as "supervisor"
 		When I view the list of exceptions

--- a/features/065-rcc-segment/test.feature
+++ b/features/065-rcc-segment/test.feature
@@ -18,7 +18,7 @@ Feature: {065} R3.5_BR7_Populate RCC with PTIURN-Offence Withdrawn
 		Given the data for this test is in the PNC
 			And "input-message" is received
 
-	@Could @NextUI
+	@Could @NextUI @Phase2Core
 	Scenario: Correctly adding RCC segment
 		Given I am logged in as "generalhandler"
 		When I view the list of exceptions

--- a/features/068-three-ccr-groups/test.feature
+++ b/features/068-three-ccr-groups/test.feature
@@ -20,6 +20,7 @@ Feature: {068} R3.5_BR7_CCR Group Matching-Offence Added In Court-Offence in CCR
 
 	@Should
 	@PreProdTest
+	@Phase2Core
 	Scenario: Handles PNC errors with 3 CCR groups
 		Given I am logged in as "generalhandler"
 			And I view the list of exceptions

--- a/features/073-court-results-transformation/test.feature
+++ b/features/073-court-results-transformation/test.feature
@@ -31,6 +31,7 @@ Feature: {073} R4.0_BR7_Convert No Conviction for 2050-2051 to Not Guilty
 
 	@Should
 	@NextUI
+	@Phase2Core
 	Scenario: Add a case to the PNC, no exceptions are flagged if certain properties are set
 		Given I am logged in as "supervisor"
 			And I view the list of exceptions

--- a/features/075-personal-details-trigger/test.feature
+++ b/features/075-personal-details-trigger/test.feature
@@ -21,6 +21,7 @@ Feature: {075} R4.0_BR7_Personal Details Trigger
 
 	@Could
 	@NextUI
+	@Phase2Core
 	Scenario: Revising ASN on the UI and removing specific result codes
 		Given I am logged in as "generalhandler"
 			And I view the list of exceptions

--- a/features/078-invalid-offence-codes/test.feature
+++ b/features/078-invalid-offence-codes/test.feature
@@ -21,6 +21,7 @@ Feature: {078} R4.0_BR7_Offence Code Schema Relaxation - schema Breaking  Offenc
 	@Could
 	@PreProdTest
 	@NextUI
+	@Phase2Core
 	Scenario: Testing invalid offence codes
 		Given the data for this test is not in the PNC
 			And "<messageId>" is received

--- a/features/079-electronic-tagging/test.feature
+++ b/features/079-electronic-tagging/test.feature
@@ -20,7 +20,7 @@ Feature: {079} R4.0.6_BR7_BA qualifier applied to curfew order result
 		Given the data for this test is in the PNC
 			And "input-message" is received
 
-	@Should @NextUI
+	@Should @NextUI @Phase2Core
 	Scenario: Correctly handling electronic tagging results
 		Given I am logged in as "generalhandler"
 		When I view the list of exceptions

--- a/features/080-fixed-penalty-notice/test.feature
+++ b/features/080-fixed-penalty-notice/test.feature
@@ -22,7 +22,7 @@ Feature: {080} R4.1-BR7-Scenario AJ-Fixed Penalty Notice for Disorder (Dealt wit
     Given the data for this test is in the PNC
       And "input-message" is received
 
-  @Must @ExcludeOnPreProd @NextUI
+  @Must @ExcludeOnPreProd @NextUI @Phase2Core
   Scenario: PNC is updated when there are multiple identical results
     Given I am logged in as "supervisor"
       And I view the list of exceptions

--- a/features/081-no-trigger-duplication/test.feature
+++ b/features/081-no-trigger-duplication/test.feature
@@ -19,6 +19,7 @@ Feature: {081} R4.1-BR7_Bail Conditions Pre Trigger
 			And "input-message" is received
 
 	@Should
+	@Phase2Core
 	Scenario: Trigger and exceptions are created and trigger is not duplicated by resubmitting the exception
 		Given I am logged in as "generalhandler"
 			And I view the list of exceptions

--- a/features/083-welsh-language-support/test.feature
+++ b/features/083-welsh-language-support/test.feature
@@ -22,7 +22,7 @@ Feature: {083} R4.1_BR7_Welsh Language Handling
       And "input-message" is received
 
   @Should
-	@Phase2Core
+  @Phase2Core
   Scenario: Using characters from the Welsh Language raises an exception
     Given I am logged in as "generalhandler"
       And I view the list of exceptions

--- a/features/083-welsh-language-support/test.feature
+++ b/features/083-welsh-language-support/test.feature
@@ -22,6 +22,7 @@ Feature: {083} R4.1_BR7_Welsh Language Handling
       And "input-message" is received
 
   @Should
+	@Phase2Core
   Scenario: Using characters from the Welsh Language raises an exception
     Given I am logged in as "generalhandler"
       And I view the list of exceptions

--- a/features/089-court-location-from-text-exception/test.feature
+++ b/features/089-court-location-from-text-exception/test.feature
@@ -19,7 +19,7 @@ Feature: {089} R4.1.1_BR7_Court Location from Text Exception
     Given the data for this test is in the PNC
       And "input-message" is received
 
-  @Should @NextUI
+  @Should @NextUI @Phase2Core
   Scenario: Updating the PNC with the court location from Text Exception
     Given I am logged in as "supervisor"
       And I view the list of exceptions

--- a/features/092-csv-download/test.feature
+++ b/features/092-csv-download/test.feature
@@ -15,6 +15,7 @@ Feature: {092} R4.1.1_BR7_CSV Report via Portal
 
   @Must
   @Parallel
+	@Phase2Core
   Scenario: Supervisors can download reports
     Given I am logged in as "supervisor"
       And I navigate to the list of reports

--- a/features/092-csv-download/test.feature
+++ b/features/092-csv-download/test.feature
@@ -15,7 +15,7 @@ Feature: {092} R4.1.1_BR7_CSV Report via Portal
 
   @Must
   @Parallel
-	@Phase2Core
+  @Phase2Core
   Scenario: Supervisors can download reports
     Given I am logged in as "supervisor"
       And I navigate to the list of reports

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:characterisation": "cd characterisation && jest --runInBand",
     "test:chunk:conductor": "bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC and not @ExcludedOnConductor'",
     "test:chunk:nextUI": "NEXTUI=true bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC and @NextUI'",
+    "test:chunk:phase2": "bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC and @Phase2Core'",
     "test:chunk": "bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC' and @ExcludedOnNextUI",
     "test:file": "./node_modules/.bin/cucumber-js --require steps/index.js --no-strict --exit --format @cucumber/pretty-formatter",
     "test:must": "./node_modules/.bin/cucumber-js --require steps/index.js --retry 5 --no-strict --exit --format @cucumber/pretty-formatter --fail-fast --tags '@Must' features",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test:characterisation": "cd characterisation && jest --runInBand",
     "test:chunk:conductor": "bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC and not @ExcludedOnConductor'",
     "test:chunk:nextUI": "NEXTUI=true bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC and @NextUI'",
-    "test:chunk:phase2": "bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC and @Phase2Core'",
     "test:chunk": "bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC' and @ExcludedOnNextUI",
     "test:file": "./node_modules/.bin/cucumber-js --require steps/index.js --no-strict --exit --format @cucumber/pretty-formatter",
     "test:must": "./node_modules/.bin/cucumber-js --require steps/index.js --retry 5 --no-strict --exit --format @cucumber/pretty-formatter --fail-fast --tags '@Must' features",

--- a/scripts/run_test_chunk.sh
+++ b/scripts/run_test_chunk.sh
@@ -16,6 +16,12 @@ if [ "${PHASE2_CORE_CANARY_RATIO}x" == "1.0x" ] || [ "${PHASE2_CORE_CANARY_RATIO
   TAGS="${TAGS} and @Phase2Core"
 fi
 
-echo "Running tests using the following tags: ${TAGS}\n"
+echo "---------------------------------------------"
+echo "Running tests using the following parameters:"
+echo "Tags: ${TAGS}"
+echo "Message entry point: $MESSAGE_ENTRY_POINT"
+echo "Next UI: $NEXTUI"
+echo "Phase 2 canary ratio: $PHASE2_CORE_CANARY_RATIO"
+echo "---------------------------------------------"
 
 ./node_modules/.bin/cucumber-js --require steps/index.js --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter  --format junit:./cucumber/results/test-results.xml --tags "${TAGS}" $CHUNK

--- a/scripts/run_test_chunk.sh
+++ b/scripts/run_test_chunk.sh
@@ -6,7 +6,7 @@ TAGS=$1
 CHUNK=${CHUNK:-$(find features -iname '*.feature' | sort | awk "(NR % $TOTAL_CHUNKS == $CHUNK_NUMBER)" | paste -d ' ' -s -)}
 NEXTUI=${NEXTUI:-"false"}
 
-if [ "$NEXTUI" == "true" ]; then
+if [ "${NEXTUI}x" == "truex" ]; then
   TAGS="${TAGS} and @NextUI"
 else
   TAGS="${TAGS} and not @ExcludeOnLegacyUI"

--- a/scripts/run_test_chunk.sh
+++ b/scripts/run_test_chunk.sh
@@ -12,4 +12,10 @@ else
   TAGS="${TAGS} and not @ExcludeOnLegacyUI"
 fi
 
+if [[ "$PHASE2_CORE_CANARY_RATIO" -eq 1 ]]; then
+  TAGS="${TAGS} and @Phase2Core"
+fi
+
+echo "Tags: ${TAGS}"
+
 ./node_modules/.bin/cucumber-js --require steps/index.js --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter  --format junit:./cucumber/results/test-results.xml --tags "${TAGS}" $CHUNK

--- a/scripts/run_test_chunk.sh
+++ b/scripts/run_test_chunk.sh
@@ -12,10 +12,10 @@ else
   TAGS="${TAGS} and not @ExcludeOnLegacyUI"
 fi
 
-if [[ "$PHASE2_CORE_CANARY_RATIO" -eq 1 ]]; then
+if [ "${PHASE2_CORE_CANARY_RATIO}x" == "1.0x" ] || [ "${PHASE2_CORE_CANARY_RATIO}x" == "1x" ]; then
   TAGS="${TAGS} and @Phase2Core"
 fi
 
-echo "Tags: ${TAGS}"
+echo "Running tests using the following tags: ${TAGS}\n"
 
 ./node_modules/.bin/cucumber-js --require steps/index.js --retry 5 --no-strict --exit --publish-quiet --format @cucumber/pretty-formatter  --format junit:./cucumber/results/test-results.xml --tags "${TAGS}" $CHUNK


### PR DESCRIPTION
In this PR:

- Added CI jobs: `test-e2e-phase2-core` and `test-e2e-phase2-core-new-ui`
- These jobs run e2e tests tagged with `Phase2Core` against the new Phase 2 Core
- Tagged passing e2e tests with `Phase2Core` for current Phase 2 Core implementation
