### PR TITLE
Add NPM scripts for legacy Bichard characterisation tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,32 +196,30 @@ jobs:
       image: ubuntu-2204:current
       docker_layer_caching: false
     resource_class: large
-    environment:
-      ENABLE_PHASE_2: "false"
-      ENABLE_PHASE_3: "false"
     steps:
       - attach_workspace:
           at: ~/
       - set_locale
       - node_install
-      - start_bichard7_legacy
-      - run: npm run test:characterisation:bichard
+      - start_bichard7_legacy:
+          ENABLE_PHASE_2: "false"
+          ENABLE_PHASE_3: "false"
+      - run: npm run test:characterisation:bichard:phase1
 
   test_characterisation_legacy_phase2:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
     resource_class: large
-    environment:
-      ENABLE_PHASE_2: "true"
-      ENABLE_PHASE_3: "false"
     steps:
       - attach_workspace:
           at: ~/
       - set_locale
       - node_install
-      - start_bichard7_legacy
-      - run: npm run test:characterisation:bichard
+      - start_bichard7_legacy:
+          ENABLE_PHASE_2: "true"
+          ENABLE_PHASE_3: "false"
+      - run: npm run test:characterisation:bichard:phase2
 
   test_characterisation_core:
     machine:

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ ENABLE_PHASE_2=true ENABLE_PHASE_3=false npm run all-legacy
 
 ```bash
 # For Phase 1:
-ENABLE_PHASE_2=false ENABLE_PHASE_3=false npm run test:characterisation:bichard
+npm run test:characterisation:bichard:phase1
 
 # For Phase 2:
-ENABLE_PHASE_2=true ENABLE_PHASE_3=false npm run test:characterisation:bichard
+npm run test:characterisation:bichard:phase2
 ```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test:browser-noteardown": "NO_TEARDOWN=true npm run test:browser",
     "test:browser": "HEADLESS=false npm run test",
     "test:characterisation:bichard": "cd characterisation && USE_BICHARD=true  jest --runInBand",
+    "test:characterisation:bichard:phase1": "ENABLE_PHASE_2=false ENABLE_PHASE_3=false npm run test:characterisation:bichard",
+    "test:characterisation:bichard:phase2": "ENABLE_PHASE_2=true ENABLE_PHASE_3=false npm run test:characterisation:bichard",
     "test:characterisation": "cd characterisation && jest --runInBand",
     "test:chunk:conductor": "bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC and not @ExcludedOnConductor'",
     "test:chunk:nextUI": "NEXTUI=true bash ./scripts/run_test_chunk.sh 'not @Excluded and not @ExcludedOnMaster and not @OnlyRunsOnPNC and @NextUI'",


### PR DESCRIPTION
The amount of times I've run the wrong command for characterisation tests for legacy Bichard is too damn high!