### PR TITLE
Add HO200112 characterisation tests

### DIFF
--- a/characterisation/exceptions/HO200112.test.ts
+++ b/characterisation/exceptions/HO200112.test.ts
@@ -1,0 +1,38 @@
+import World from "../../utils/world"
+import { generateMessage } from "../helpers/generateMessage"
+import { processPhase2Message } from "../helpers/processMessage"
+
+jest.setTimeout(30000)
+
+describe.ifPhase2("HO200112", () => {
+  afterAll(async () => {
+    await new World({}).db.closeConnection()
+  })
+
+  it.each([
+    {
+      templateFile: "test-data/HO200112/aho.xml.njk",
+      messageType: "AHO"
+    },
+    {
+      templateFile: "test-data/HO200112/pud.xml.njk",
+      messageType: "PncUpdateDataset"
+    }
+  ])(
+    "creates a HO200112 exception for $messageType when result with judgement with final result and sentence",
+    async ({ templateFile }) => {
+      const inputMessage = generateMessage(templateFile, {})
+
+      const {
+        outputMessage: { Exceptions: exceptions }
+      } = await processPhase2Message(inputMessage)
+
+      expect(exceptions).toStrictEqual([
+        {
+          code: "HO200112",
+          path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "HearingDefendant", "ArrestSummonsNumber"]
+        }
+      ])
+    }
+  )
+})

--- a/characterisation/test-data/HO200112/aho.xml.njk
+++ b/characterisation/test-data/HO200112/aho.xml.njk
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<br7:AnnotatedHearingOutcome
+        xmlns:br7="http://schemas.cjse.gov.uk/datastandards/BR7/2007-12"
+        xmlns:ds="http://schemas.cjse.gov.uk/datastandards/2006-10"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <br7:HearingOutcome>
+        <br7:Hearing hasError="false" SchemaVersion="4.0">
+            <ds:CourtHearingLocation SchemaVersion="2.0">
+                <ds:TopLevelCode>B</ds:TopLevelCode>
+                <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                <ds:ThirdLevelCode>EF</ds:ThirdLevelCode>
+                <ds:BottomLevelCode>01</ds:BottomLevelCode>
+                <ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>
+            </ds:CourtHearingLocation>
+            <ds:DateOfHearing>2011-09-26</ds:DateOfHearing>
+            <ds:TimeOfHearing>10:00</ds:TimeOfHearing>
+            <ds:HearingLanguage Literal="Don't Know">D</ds:HearingLanguage>
+            <ds:HearingDocumentationLanguage Literal="Don't Know">D</ds:HearingDocumentationLanguage>
+            <ds:DefendantPresentAtHearing Literal="Defendant was not present, but appeared by the presence of his/her barrister or solicitor">A</ds:DefendantPresentAtHearing>
+            <br7:SourceReference>
+                <br7:DocumentName>SPI JOHN SMITH</br7:DocumentName>
+                <br7:UniqueID>EXTERNAL_CORRELATION_ID</br7:UniqueID>
+                <br7:DocumentType>SPI Case Result</br7:DocumentType>
+            </br7:SourceReference>
+            <br7:CourtType Literal="MC adult">MCA</br7:CourtType>
+            <br7:CourtHouseCode>2576</br7:CourtHouseCode>
+            <br7:CourtHouseName>London Croydon</br7:CourtHouseName>
+        </br7:Hearing>
+        <br7:Case hasError="false" SchemaVersion="4.0">
+            <ds:PTIURN>01ZD0303208</ds:PTIURN>
+            <ds:PreChargeDecisionIndicator Literal="No">N</ds:PreChargeDecisionIndicator>
+            <ds:CourtCaseReferenceNumber>97/1626/008395Q</ds:CourtCaseReferenceNumber>
+            <br7:CourtReference>
+                <ds:MagistratesCourtReference>01ZD0303208</ds:MagistratesCourtReference>
+            </br7:CourtReference>
+            <br7:RecordableOnPNCindicator Literal="Yes">Y</br7:RecordableOnPNCindicator>
+            <br7:Urgent>
+                <br7:urgent Literal="Yes">Y</br7:urgent>
+                <br7:urgency>24</br7:urgency>
+            </br7:Urgent>
+            <br7:ForceOwner SchemaVersion="2.0">
+                <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                <ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>
+                <ds:BottomLevelCode>00</ds:BottomLevelCode>
+                <ds:OrganisationUnitCode>01ZD00</ds:OrganisationUnitCode>
+            </br7:ForceOwner>
+            <br7:HearingDefendant hasError="false">
+                <br7:ArrestSummonsNumber>1101ZD0100000448754K</br7:ArrestSummonsNumber>
+                <br7:PNCIdentifier>2000/0448754K</br7:PNCIdentifier>
+                <br7:PNCCheckname>SMITH</br7:PNCCheckname>
+                <br7:DefendantDetail>
+                    <br7:PersonName>
+                        <ds:Title>Mr</ds:Title>
+                        <ds:GivenName NameSequence="1">JOHN</ds:GivenName>
+                        <ds:FamilyName NameSequence="1">SMITH</ds:FamilyName>
+                    </br7:PersonName>
+                    <br7:GeneratedPNCFilename>SMITH/JOHN</br7:GeneratedPNCFilename>
+                    <br7:BirthDate>1948-11-11</br7:BirthDate>
+                    <br7:Gender Literal="male">1</br7:Gender>
+                </br7:DefendantDetail>
+                <br7:Address>
+                    <ds:AddressLine1>Address Line 1</ds:AddressLine1>
+                    <ds:AddressLine2>Address Line 2</ds:AddressLine2>
+                    <ds:AddressLine3>Address Line 3</ds:AddressLine3>
+                </br7:Address>
+                <br7:RemandStatus Literal="Unconditional Bail">UB</br7:RemandStatus>
+                <br7:Offence hasError="false" SchemaVersion="4.0">
+                    <ds:CriminalProsecutionReference SchemaVersion="2.0">
+                        <ds:DefendantOrOffender>
+                            <ds:Year>11</ds:Year>
+                            <ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
+                                <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                                <ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>
+                                <ds:BottomLevelCode>01</ds:BottomLevelCode>
+                                <ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>
+                            </ds:OrganisationUnitIdentifierCode>
+                            <ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>
+                            <ds:CheckDigit>K</ds:CheckDigit>
+                        </ds:DefendantOrOffender>
+                        <ds:OffenceReason>
+                            <ds:OffenceCode>
+                                <ds:ActOrSource>RT</ds:ActOrSource>
+                                <ds:Year>88</ds:Year>
+                                <ds:Reason>191</ds:Reason>
+                            </ds:OffenceCode>
+                        </ds:OffenceReason>
+                        <ds:OffenceReasonSequence>001</ds:OffenceReasonSequence>
+                    </ds:CriminalProsecutionReference>
+                    <ds:OffenceCategory Literal="Summary Motoring">CM</ds:OffenceCategory>
+                    <ds:ArrestDate>2010-12-01</ds:ArrestDate>
+                    <ds:ChargeDate>2010-12-02</ds:ChargeDate>
+                    <ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>
+                    <ds:ActualOffenceStartDate>
+                        <ds:StartDate>2010-11-28</ds:StartDate>
+                    </ds:ActualOffenceStartDate>
+                    <ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>
+                    <ds:OffenceTitle>Use a motor vehicle on a road / public place without third party insurance
+                    </ds:OffenceTitle>
+                    <ds:ActualOffenceWording>Use a motor vehicle without third party insurance.
+                    </ds:ActualOffenceWording>
+                    <ds:RecordableOnPNCindicator Literal="No">N</ds:RecordableOnPNCindicator>
+                    <ds:NotifiableToHOindicator Literal="No">N</ds:NotifiableToHOindicator>
+                    <ds:HomeOfficeClassification>809/01</ds:HomeOfficeClassification>
+                    <ds:ConvictionDate>2011-09-26</ds:ConvictionDate>
+                    <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
+                    <br7:CourtOffenceSequenceNumber>3</br7:CourtOffenceSequenceNumber>
+                    <br7:Result hasError="false" SchemaVersion="2.0">
+                        <ds:CJSresultCode>1015</ds:CJSresultCode>
+                        <ds:SourceOrganisation SchemaVersion="2.0">
+                            <ds:TopLevelCode>B</ds:TopLevelCode>
+                            <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                            <ds:ThirdLevelCode>EF</ds:ThirdLevelCode>
+                            <ds:BottomLevelCode>01</ds:BottomLevelCode>
+                            <ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>
+                        </ds:SourceOrganisation>
+                        <ds:CourtType>MCA</ds:CourtType>
+                        <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
+                        <ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>
+                        <ds:AmountSpecifiedInResult Type="Fine">100.00</ds:AmountSpecifiedInResult>
+                        <ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
+                        <ds:Verdict Literal="Guilty">G</ds:Verdict>
+                        <ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>
+                        <ds:ResultVariableText>Fined 100.</ds:ResultVariableText>
+                        <ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
+                        <br7:PNCDisposalType>1015</br7:PNCDisposalType>
+                        <br7:ResultClass>Judgement with final result</br7:ResultClass>
+                        <br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>
+                    </br7:Result>
+                    <br7:Result hasError="false" SchemaVersion="2.0">
+                        <ds:CJSresultCode>1015</ds:CJSresultCode>
+                        <ds:SourceOrganisation SchemaVersion="2.0">
+                            <ds:TopLevelCode>B</ds:TopLevelCode>
+                            <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                            <ds:ThirdLevelCode>EF</ds:ThirdLevelCode>
+                            <ds:BottomLevelCode>01</ds:BottomLevelCode>
+                            <ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>
+                        </ds:SourceOrganisation>
+                        <ds:CourtType>MCA</ds:CourtType>
+                        <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
+                        <ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>
+                        <ds:AmountSpecifiedInResult Type="Fine">100.00</ds:AmountSpecifiedInResult>
+                        <ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
+                        <ds:Verdict Literal="Guilty">G</ds:Verdict>
+                        <ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>
+                        <ds:ResultVariableText>Fined 100.</ds:ResultVariableText>
+                        <ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
+                        <br7:PNCDisposalType>1015</br7:PNCDisposalType>
+                        <br7:ResultClass>Sentence</br7:ResultClass>
+                        <br7:PNCAdjudicationExists Literal="Yes">Y</br7:PNCAdjudicationExists>
+                    </br7:Result>
+                </br7:Offence>
+            </br7:HearingDefendant>
+        </br7:Case>
+    </br7:HearingOutcome>
+    <br7:HasError>false</br7:HasError>
+    <CXE01>
+        <FSC FSCode="01ZD" IntfcUpdateType="K" />
+        <IDS CRONumber="" Checkname="SMITH" IntfcUpdateType="K" PNCID="" />
+        <CourtCases>
+            <CourtCase>
+                <CCR CourtCaseRefNo="97/1626/008395Q" CrimeOffenceRefNo="" IntfcUpdateType="K" />
+                <Offences>
+                    <Offence>
+                        <COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="RT88191" IntfcUpdateType="K" OffEndDate=""
+                             OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1=""
+                             OffenceQualifier2=""
+                             OffenceTitle="Use a motor vehicle on a road / public place without third party insurance"
+                             ReferenceNumber="001" />
+                        <ADJ Adjudication1="GUILTY" DateOfSentence="26092007" IntfcUpdateType="I"
+                             OffenceTICNumber="0000" Plea="NOT GUILTY" WeedFlag="" />
+                        <DISList>
+                            <DIS IntfcUpdateType="I" QtyDate="" QtyDuration="W2" QtyMonetaryValue=""
+                                 QtyUnitsFined="" Qualifiers="ABS     W12" Text="" Type="1000" />
+                        </DISList>
+                    </Offence>
+                </Offences>
+            </CourtCase>
+        </CourtCases>
+    </CXE01>
+    <br7:PNCQueryDate>2022-03-22</br7:PNCQueryDate>
+</br7:AnnotatedHearingOutcome>

--- a/characterisation/test-data/HO200112/pud.xml.njk
+++ b/characterisation/test-data/HO200112/pud.xml.njk
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<PNCUpdateDataset xmlns="http://www.example.org/NewXMLSchema"
+                  xmlns:ds="http://schemas.cjse.gov.uk/datastandards/2006-10"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <br7:AnnotatedHearingOutcome xmlns:br7="http://schemas.cjse.gov.uk/datastandards/BR7/2007-12">
+        <br7:HearingOutcome>
+            <br7:Hearing hasError="false" SchemaVersion="4.0">
+                <ds:CourtHearingLocation SchemaVersion="2.0">
+                    <ds:TopLevelCode>B</ds:TopLevelCode>
+                    <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                    <ds:ThirdLevelCode>EF</ds:ThirdLevelCode>
+                    <ds:BottomLevelCode>01</ds:BottomLevelCode>
+                    <ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>
+                </ds:CourtHearingLocation>
+                <ds:DateOfHearing>2011-09-26</ds:DateOfHearing>
+                <ds:TimeOfHearing>10:00</ds:TimeOfHearing>
+                <ds:HearingLanguage Literal="Don't Know">D</ds:HearingLanguage>
+                <ds:HearingDocumentationLanguage Literal="Don't Know">D</ds:HearingDocumentationLanguage>
+                <ds:DefendantPresentAtHearing
+                        Literal="Defendant was not present, but appeared by the presence of his/her barrister or solicitor">
+                    A
+                </ds:DefendantPresentAtHearing>
+                <br7:SourceReference>
+                    <br7:DocumentName>SPI JOHN SMITH</br7:DocumentName>
+                    <br7:UniqueID>EXTERNAL_CORRELATION_ID</br7:UniqueID>
+                    <br7:DocumentType>SPI Case Result</br7:DocumentType>
+                </br7:SourceReference>
+                <br7:CourtType Literal="MC adult">MCA</br7:CourtType>
+                <br7:CourtHouseCode>2576</br7:CourtHouseCode>
+                <br7:CourtHouseName>London Croydon</br7:CourtHouseName>
+            </br7:Hearing>
+            <br7:Case hasError="false" SchemaVersion="4.0">
+                <ds:PTIURN>01ZD0303208</ds:PTIURN>
+                <ds:PreChargeDecisionIndicator Literal="No">N</ds:PreChargeDecisionIndicator>
+                <ds:CourtCaseReferenceNumber>97/1626/008395Q</ds:CourtCaseReferenceNumber>
+                <br7:CourtReference>
+                    <ds:MagistratesCourtReference>01ZD0303208</ds:MagistratesCourtReference>
+                </br7:CourtReference>
+                <br7:RecordableOnPNCindicator Literal="Yes">Y</br7:RecordableOnPNCindicator>
+                <br7:Urgent>
+                    <br7:urgent Literal="Yes">Y</br7:urgent>
+                    <br7:urgency>24</br7:urgency>
+                </br7:Urgent>
+                <br7:ForceOwner SchemaVersion="2.0">
+                    <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                    <ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>
+                    <ds:BottomLevelCode>00</ds:BottomLevelCode>
+                    <ds:OrganisationUnitCode>01ZD00</ds:OrganisationUnitCode>
+                </br7:ForceOwner>
+                <br7:HearingDefendant hasError="false">
+                    <br7:ArrestSummonsNumber>1101ZD0100000448754K</br7:ArrestSummonsNumber>
+                    <br7:PNCIdentifier>2000/0448754K</br7:PNCIdentifier>
+                    <br7:PNCCheckname>SMITH</br7:PNCCheckname>
+                    <br7:DefendantDetail>
+                        <br7:PersonName>
+                            <ds:Title>Mr</ds:Title>
+                            <ds:GivenName NameSequence="1">JOHN</ds:GivenName>
+                            <ds:FamilyName NameSequence="1">SMITH</ds:FamilyName>
+                        </br7:PersonName>
+                        <br7:GeneratedPNCFilename>SMITH/JOHN</br7:GeneratedPNCFilename>
+                        <br7:BirthDate>1948-11-11</br7:BirthDate>
+                        <br7:Gender Literal="male">1</br7:Gender>
+                    </br7:DefendantDetail>
+                    <br7:Address>
+                        <ds:AddressLine1>Address Line 1</ds:AddressLine1>
+                        <ds:AddressLine2>Address Line 2</ds:AddressLine2>
+                        <ds:AddressLine3>Address Line 3</ds:AddressLine3>
+                    </br7:Address>
+                    <br7:RemandStatus Literal="Unconditional Bail">UB</br7:RemandStatus>
+                    <br7:Offence hasError="false" SchemaVersion="4.0">
+                        <ds:CriminalProsecutionReference SchemaVersion="2.0">
+                            <ds:DefendantOrOffender>
+                                <ds:Year>11</ds:Year>
+                                <ds:OrganisationUnitIdentifierCode SchemaVersion="2.0">
+                                    <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                                    <ds:ThirdLevelCode>ZD</ds:ThirdLevelCode>
+                                    <ds:BottomLevelCode>01</ds:BottomLevelCode>
+                                    <ds:OrganisationUnitCode>01ZD01</ds:OrganisationUnitCode>
+                                </ds:OrganisationUnitIdentifierCode>
+                                <ds:DefendantOrOffenderSequenceNumber>00000448754</ds:DefendantOrOffenderSequenceNumber>
+                                <ds:CheckDigit>K</ds:CheckDigit>
+                            </ds:DefendantOrOffender>
+                            <ds:OffenceReason>
+                                <ds:OffenceCode>
+                                    <ds:ActOrSource>RT</ds:ActOrSource>
+                                    <ds:Year>88</ds:Year>
+                                    <ds:Reason>191</ds:Reason>
+                                </ds:OffenceCode>
+                            </ds:OffenceReason>
+                            <ds:OffenceReasonSequence>001</ds:OffenceReasonSequence>
+                        </ds:CriminalProsecutionReference>
+                        <ds:OffenceCategory Literal="Summary Motoring">CM</ds:OffenceCategory>
+                        <ds:ArrestDate>2010-12-01</ds:ArrestDate>
+                        <ds:ChargeDate>2010-12-02</ds:ChargeDate>
+                        <ds:ActualOffenceDateCode Literal="on or in">1</ds:ActualOffenceDateCode>
+                        <ds:ActualOffenceStartDate>
+                            <ds:StartDate>2010-11-28</ds:StartDate>
+                        </ds:ActualOffenceStartDate>
+                        <ds:LocationOfOffence>Kingston High Street</ds:LocationOfOffence>
+                        <ds:OffenceTitle>Use a motor vehicle on a road / public place without third party insurance
+                        </ds:OffenceTitle>
+                        <ds:ActualOffenceWording>Use a motor vehicle without third party insurance.
+                        </ds:ActualOffenceWording>
+                        <ds:RecordableOnPNCindicator Literal="No">N</ds:RecordableOnPNCindicator>
+                        <ds:NotifiableToHOindicator Literal="No">N</ds:NotifiableToHOindicator>
+                        <ds:HomeOfficeClassification>809/01</ds:HomeOfficeClassification>
+                        <ds:ConvictionDate>2011-09-26</ds:ConvictionDate>
+                        <br7:CommittedOnBail Literal="Don't Know">D</br7:CommittedOnBail>
+                        <br7:CourtOffenceSequenceNumber>3</br7:CourtOffenceSequenceNumber>
+                        <br7:Result hasError="false" SchemaVersion="2.0">
+                            <ds:CJSresultCode>1015</ds:CJSresultCode>
+                            <ds:SourceOrganisation SchemaVersion="2.0">
+                                <ds:TopLevelCode>B</ds:TopLevelCode>
+                                <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                                <ds:ThirdLevelCode>EF</ds:ThirdLevelCode>
+                                <ds:BottomLevelCode>01</ds:BottomLevelCode>
+                                <ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>
+                            </ds:SourceOrganisation>
+                            <ds:CourtType>MCA</ds:CourtType>
+                            <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
+                            <ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>
+                            <ds:AmountSpecifiedInResult Type="Fine">100.00</ds:AmountSpecifiedInResult>
+                            <ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
+                            <ds:Verdict Literal="Guilty">G</ds:Verdict>
+                            <ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>
+                            <ds:ResultVariableText>Fined 100.</ds:ResultVariableText>
+                            <ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
+                            <br7:PNCDisposalType>1015</br7:PNCDisposalType>
+                            <br7:ResultClass>Judgement with final result</br7:ResultClass>
+                            <br7:PNCAdjudicationExists Literal="No">N</br7:PNCAdjudicationExists>
+                        </br7:Result>
+                        <br7:Result hasError="false" SchemaVersion="2.0">
+                            <ds:CJSresultCode>1015</ds:CJSresultCode>
+                            <ds:SourceOrganisation SchemaVersion="2.0">
+                                <ds:TopLevelCode>B</ds:TopLevelCode>
+                                <ds:SecondLevelCode>01</ds:SecondLevelCode>
+                                <ds:ThirdLevelCode>EF</ds:ThirdLevelCode>
+                                <ds:BottomLevelCode>01</ds:BottomLevelCode>
+                                <ds:OrganisationUnitCode>B01EF01</ds:OrganisationUnitCode>
+                            </ds:SourceOrganisation>
+                            <ds:CourtType>MCA</ds:CourtType>
+                            <ds:ResultHearingType Literal="Other">OTHER</ds:ResultHearingType>
+                            <ds:ResultHearingDate>2011-09-26</ds:ResultHearingDate>
+                            <ds:AmountSpecifiedInResult Type="Fine">100.00</ds:AmountSpecifiedInResult>
+                            <ds:PleaStatus Literal="Not Guilty">NG</ds:PleaStatus>
+                            <ds:Verdict Literal="Guilty">G</ds:Verdict>
+                            <ds:ModeOfTrialReason Literal="Summary only">SUM</ds:ModeOfTrialReason>
+                            <ds:ResultVariableText>Fined 100.</ds:ResultVariableText>
+                            <ds:ResultHalfLifeHours>72</ds:ResultHalfLifeHours>
+                            <br7:PNCDisposalType>1015</br7:PNCDisposalType>
+                            <br7:ResultClass>Sentence</br7:ResultClass>
+                            <br7:PNCAdjudicationExists Literal="Yes">Y</br7:PNCAdjudicationExists>
+                        </br7:Result>
+                    </br7:Offence>
+                </br7:HearingDefendant>
+            </br7:Case>
+        </br7:HearingOutcome>
+        <br7:HasError>false</br7:HasError>
+        <CXE01 xmlns="">
+            <FSC FSCode="01ZD" IntfcUpdateType="K" />
+            <IDS CRONumber="" Checkname="SMITH" IntfcUpdateType="K" PNCID="" />
+            <CourtCases>
+                <CourtCase>
+                    <CCR CourtCaseRefNo="97/1626/008395Q" CrimeOffenceRefNo="" IntfcUpdateType="K" />
+                    <Offences>
+                        <Offence>
+                            <COF ACPOOffenceCode="12:15:24:1" CJSOffenceCode="RT88191" IntfcUpdateType="K" OffEndDate=""
+                                 OffEndTime="" OffStartDate="28112010" OffStartTime="0000" OffenceQualifier1=""
+                                 OffenceQualifier2=""
+                                 OffenceTitle="Use a motor vehicle on a road / public place without third party insurance"
+                                 ReferenceNumber="001" />
+                            <ADJ Adjudication1="GUILTY" DateOfSentence="26092007" IntfcUpdateType="I"
+                                 OffenceTICNumber="0000" Plea="NOT GUILTY" WeedFlag="" />
+                            <DISList>
+                                <DIS IntfcUpdateType="I" QtyDate="" QtyDuration="W2" QtyMonetaryValue=""
+                                     QtyUnitsFined="" Qualifiers="ABS     W12" Text="" Type="1000" />
+                            </DISList>
+                        </Offence>
+                    </Offences>
+                </CourtCase>
+            </CourtCases>
+        </CXE01>
+        <br7:PNCQueryDate>2022-03-22</br7:PNCQueryDate>
+    </br7:AnnotatedHearingOutcome>
+</PNCUpdateDataset>


### PR DESCRIPTION
- I've only created tests for the happy path as I don't see any value in doing an unhappy path for the exceptions generated when validating operations as it's literally anything else i.e. "NOT this very specific journey through the code".
  - Also, we'll have other characterisation tests for all the other exceptions raised in `validateOperations`.
- Worth noting the input message required multiple results for an offence to match the two operations required to generate the exception.
  - Also the order of the results mattered!

https://dsdmoj.atlassian.net/browse/BICAWS7-3054