### PR TITLE
Add HO200114 characterisation tests

### DIFF
--- a/characterisation/exceptions/HO200114.test.ts
+++ b/characterisation/exceptions/HO200114.test.ts
@@ -1,0 +1,64 @@
+import World from "../../utils/world"
+import { processPhase2Message } from "../helpers/processMessage"
+import { asnPath } from "../helpers/errorPaths"
+import generatePhase2Message from "../helpers/generatePhase2Message"
+import MessageType from "../types/MessageType"
+import { ResultClass } from "../types/ResultClass"
+
+describe.ifPhase2("HO200114", () => {
+  afterAll(async () => {
+    await new World({}).db.closeConnection()
+  })
+
+  it("creates a HO200114 exception for PncUpdateDataset when results with judgement with final result and sentence", async () => {
+    const inputMessage = generatePhase2Message({
+      messageType: MessageType.PNC_UPDATE_DATASET,
+      offences: [
+        {
+          results: [
+            { resultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, pncAdjudicationExists: true },
+            { resultClass: ResultClass.SENTENCE, pncAdjudicationExists: true }
+          ]
+        }
+      ],
+      pncAdjudication: {},
+      pncDisposals: [{ type: 1000 }]
+    })
+
+    const {
+      outputMessage: { Exceptions: exceptions }
+    } = await processPhase2Message(inputMessage)
+
+    expect(exceptions).toStrictEqual([
+      {
+        code: "HO200114",
+        path: asnPath
+      }
+    ])
+  })
+
+  it("doesn't create a HO200114 exception for AHO when results with judgement with final result and sentence", async () => {
+    const inputMessage = generatePhase2Message({
+      messageType: MessageType.ANNOTATED_HEARING_OUTCOME,
+      offences: [
+        {
+          results: [
+            { resultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, pncAdjudicationExists: true },
+            { resultClass: ResultClass.SENTENCE, pncAdjudicationExists: true }
+          ]
+        }
+      ],
+      pncAdjudication: {},
+      pncDisposals: [{ type: 1000 }]
+    })
+
+    const {
+      outputMessage: { Exceptions: exceptions }
+    } = await processPhase2Message(inputMessage)
+
+    expect(exceptions).not.toContainEqual({
+      code: "HO200114",
+      path: asnPath
+    })
+  })
+})


### PR DESCRIPTION
There are two scenarios in which a HO200114 exception can be raised:

1. when a SENDEF and SUBVAR operation are generated
2. when a SENDEF and PENHRG operation are generated

These operations are then validated within `validateOperations` and an exception is raised if they are found together.

Scenario 1 is the only possibility and only for a PncUpdateDataset.

This is because:

1. a SENDEF can only be generated if an offence result is a SENTENCE and NOT fixed penalty and there is NOT a PNC result which is 2007.
2. a SUBVAR can be generated if an offence result is JUDGEMENT WITH FINAL RESULT and NOT fixed penalty:
   a. the input message is resubmitted e.g. PncUpdateDataset
   b. or ALL PNC results are 2007
3. a SUBVAR can be generated if an offence result is a SENTENCE and there is at least ONE PNC result which is 2007.
4. a PENHRG can generated if an offence result is a SENTENCE and a fixed penalty.
5. a PENHRG can generated if an offence result is a JUDGEMENT WITH FINAL RESULT and a fixed penalty.

For scenario 1 (SENDEF and SUBVAR):

- This is possible for a PncUpdateDataset because a combination of option 1 and 2a.
- For an AHO it's not possible because option 1 conflicts with option 2b and 3, the only options for an AHO.

For scenario 2 (SENDEF and PENHRG):

- Option 1 is when only when a SENDEF can be generated which directly conflicts with option 4 and 5, the only ways to generate a PENHRG and fixed penalty is on a case, not on a result.

https://dsdmoj.atlassian.net/browse/BICAWS7-3024