### PR TITLE
Add TRPS0004 characterisation tests

### DIFF
--- a/characterisation/helpers/generatePhase2Message.ts
+++ b/characterisation/helpers/generatePhase2Message.ts
@@ -8,6 +8,17 @@ type PncDisposal = {
 
 type PncAdjudication = {}
 
+enum PncOperationStatus {
+  F = "Failed",
+  C = "Completed",
+  N = "NotAttempted"
+}
+
+type PncOperation = {
+  code: "NEWREM"
+  status?: PncOperationStatus
+}
+
 export type Duration = {
   type: string
   unit: string
@@ -55,6 +66,7 @@ export type GeneratePhase2MessageOptions = {
   pncId?: string
   pncAdjudication?: PncAdjudication
   pncDisposals?: PncDisposal[]
+  pncOperations?: PncOperation[]
 }
 
 const updateOptionsForNoOperationsAndExceptions = (

--- a/characterisation/test-data/Phase2Message.xml.njk
+++ b/characterisation/test-data/Phase2Message.xml.njk
@@ -224,7 +224,16 @@
   </CXE01>
   <br7:PNCQueryDate>2022-03-22</br7:PNCQueryDate>
 </br7:AnnotatedHearingOutcome>
-
 {% if messageType == "PncUpdateDataset" %}
+  {% for pncOperation in pncOperations %}
+  <Operation>
+    <operationCode>
+      {% if pncOperation.code == "NEWREM" %}
+      <NEWREM/>
+      {% endif %}
+    </operationCode>
+    <operationStatus>{{ pncOperation.status if pncOperation.status else "N" }}</operationStatus>
+  </Operation>
+  {% endfor %}
 </PNCUpdateDataset>
 {% endif %}

--- a/characterisation/triggers/TRPS0004.test.ts
+++ b/characterisation/triggers/TRPS0004.test.ts
@@ -1,0 +1,41 @@
+import World from "../../utils/world"
+import generatePhase2Message from "../helpers/generatePhase2Message"
+import { processPhase2Message } from "../helpers/processMessage"
+import MessageType from "../types/MessageType"
+import { TriggerCode } from "../types/TriggerCode"
+
+describe.ifPhase2("TRPS0004", () => {
+  afterAll(async () => {
+    await new World({}).db.closeConnection()
+  })
+
+  it.ifNewBichard(
+    "creates a TRPS0004 for PncUpdateDataset when hearing outcome is AINT case with existing NEWREM operation",
+    async () => {
+      const inputMessage = generatePhase2Message({
+        messageType: MessageType.PNC_UPDATE_DATASET,
+        hoTemplate: "AintCase",
+        pncOperations: [{ code: "NEWREM" }]
+      })
+
+      const { triggers } = await processPhase2Message(inputMessage)
+
+      expect(triggers).toContainEqual({ code: TriggerCode.TRPS0004 })
+    }
+  )
+
+  it.ifNewBichard(
+    "creates a TRPS0004 for PncUpdateDataset when no operations and exceptions are generated but with existing NEWREM operation",
+    async () => {
+      const inputMessage = generatePhase2Message({
+        messageType: MessageType.PNC_UPDATE_DATASET,
+        hoTemplate: "NoOperationsAndExceptions",
+        pncOperations: [{ code: "NEWREM" }]
+      })
+
+      const { triggers } = await processPhase2Message(inputMessage)
+
+      expect(triggers).toContainEqual({ code: TriggerCode.TRPS0004 })
+    }
+  )
+})

--- a/characterisation/types/TriggerCode.ts
+++ b/characterisation/types/TriggerCode.ts
@@ -25,5 +25,6 @@ export enum TriggerCode {
   TRPR0029 = "TRPR0029",
   TRPR0030 = "TRPR0030",
   TRPS0002 = "TRPS0002",
+  TRPS0004 = "TRPS0004",
   TRPS0011 = "TRPS0011"
 }


### PR DESCRIPTION
These tests only work for new Bichard because this trigger is only raised for PncUpdateDataset and legacy doesn't check for AINT case for PncUpdateDataset and doesn't populate the DB when no operations and exceptions are generated.