### PR TITLE
Add HO200109 characterisation tests

### DIFF
--- a/characterisation/exceptions/HO200109/HO200109-APPHRD-DISARR.test.ts
+++ b/characterisation/exceptions/HO200109/HO200109-APPHRD-DISARR.test.ts
@@ -1,0 +1,76 @@
+import World from "../../../utils/world"
+import generatePhase2Message from "../../helpers/generatePhase2Message"
+import { processPhase2Message } from "../../helpers/processMessage"
+import { asnPath } from "../../helpers/errorPaths"
+import MessageType from "../../types/MessageType"
+import { ResultClass } from "../../types/ResultClass"
+
+describe.ifPhase2("HO200109", () => {
+  afterAll(async () => {
+    await new World({}).db.closeConnection()
+  })
+
+  describe("when the input message generates an APPHRD and DISARR operation", () => {
+    describe("with results including appeal outcome and adjournment with judgement", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.ADJOURNMENT_WITH_JUDGEMENT }
+                ]
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+
+    describe("with results including appeal outcome and judgement with final result as well as not added by the court", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            penaltyNoticeCaseReference: false,
+            offences: [
+              {
+                addedByTheCourt: false,
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, pncAdjudicationExists: false }
+                ]
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+  })
+})

--- a/characterisation/exceptions/HO200109/HO200109-APPHRD-NEWREM-CCR.test.ts
+++ b/characterisation/exceptions/HO200109/HO200109-APPHRD-NEWREM-CCR.test.ts
@@ -1,0 +1,138 @@
+import World from "../../../utils/world"
+import generatePhase2Message from "../../helpers/generatePhase2Message"
+import { processPhase2Message } from "../../helpers/processMessage"
+import { asnPath } from "../../helpers/errorPaths"
+import MessageType from "../../types/MessageType"
+import { ResultClass } from "../../types/ResultClass"
+
+describe.ifPhase2("HO200109", () => {
+  afterAll(async () => {
+    await new World({}).db.closeConnection()
+  })
+
+  describe("when the input message generates an APPHRD and NEWREM operation with a remand court case reference", () => {
+    describe("with results with appeal outcome and adjournment as well as court case reference", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.ADJOURNMENT }
+                ],
+                courtCaseReferenceNumber: true
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+
+    describe("with results with appeal outcome and adjournment with judgement as well as court case reference", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.ADJOURNMENT_WITH_JUDGEMENT }
+                ],
+                courtCaseReferenceNumber: true
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+
+    describe("with results with appeal outcome and adjournment with post-judgement as well court case reference", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.ADJOURNMENT_POST_JUDGEMENT, pncAdjudicationExists: true }
+                ],
+                courtCaseReferenceNumber: true
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+
+    describe("with results with appeal outcome and adjournment with pre-judgement as well as court case reference", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.ADJOURNMENT_PRE_JUDGEMENT, pncAdjudicationExists: false }
+                ],
+                courtCaseReferenceNumber: true
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+  })
+})

--- a/characterisation/exceptions/HO200109/HO200109-APPHRD-NEWREM.test.ts
+++ b/characterisation/exceptions/HO200109/HO200109-APPHRD-NEWREM.test.ts
@@ -1,0 +1,107 @@
+import World from "../../../utils/world"
+import generatePhase2Message from "../../helpers/generatePhase2Message"
+import { processPhase2Message } from "../../helpers/processMessage"
+import { asnPath } from "../../helpers/errorPaths"
+import MessageType from "../../types/MessageType"
+import { ResultClass } from "../../types/ResultClass"
+
+describe.ifPhase2("HO200109", () => {
+  afterAll(async () => {
+    await new World({}).db.closeConnection()
+  })
+
+  describe("when the input message generates an APPHRD and NEWREM operation without a remand court case reference", () => {
+    describe("with results with appeal outcome and adjournment as well as no court case reference", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.ADJOURNMENT }
+                ],
+                courtCaseReferenceNumber: false
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+
+    describe("with results with appeal outcome and adjournment with post-judgement as well as no court case reference", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.ADJOURNMENT_POST_JUDGEMENT, pncAdjudicationExists: true }
+                ],
+                courtCaseReferenceNumber: false
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+
+    describe("with results with appeal outcome and adjournment with pre-judgement as well as no court case reference", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.ADJOURNMENT_PRE_JUDGEMENT, pncAdjudicationExists: false }
+                ],
+                courtCaseReferenceNumber: false
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+  })
+})

--- a/characterisation/exceptions/HO200109/HO200109-APPHRD-PENHRG.test.ts
+++ b/characterisation/exceptions/HO200109/HO200109-APPHRD-PENHRG.test.ts
@@ -1,0 +1,76 @@
+import World from "../../../utils/world"
+import generatePhase2Message from "../../helpers/generatePhase2Message"
+import { processPhase2Message } from "../../helpers/processMessage"
+import { asnPath } from "../../helpers/errorPaths"
+import MessageType from "../../types/MessageType"
+import { ResultClass } from "../../types/ResultClass"
+
+describe.ifPhase2("HO200109", () => {
+  afterAll(async () => {
+    await new World({}).db.closeConnection()
+  })
+
+  describe("when the input message generates an APPHRD and PENHRG operation", () => {
+    describe("with results including appeal outcome and sentence as well as penalty notice", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            penaltyNoticeCaseReference: true,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.SENTENCE, pncAdjudicationExists: true }
+                ]
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+
+    describe("with results including appeal outcome and judgement with final result as well as penalty notice", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            penaltyNoticeCaseReference: true,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, pncAdjudicationExists: true }
+                ]
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+  })
+})

--- a/characterisation/exceptions/HO200109/HO200109-APPHRD-SENDEF.test.ts
+++ b/characterisation/exceptions/HO200109/HO200109-APPHRD-SENDEF.test.ts
@@ -1,0 +1,45 @@
+import World from "../../../utils/world"
+import generatePhase2Message from "../../helpers/generatePhase2Message"
+import { processPhase2Message } from "../../helpers/processMessage"
+import { asnPath } from "../../helpers/errorPaths"
+import MessageType from "../../types/MessageType"
+import { ResultClass } from "../../types/ResultClass"
+
+describe.ifPhase2("HO200109", () => {
+  afterAll(async () => {
+    await new World({}).db.closeConnection()
+  })
+
+  describe("when the input message generates an APPHRD and SENDEF operation", () => {
+    describe("with results including appeal outcome and sentence", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            penaltyNoticeCaseReference: false,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.SENTENCE, pncAdjudicationExists: true }
+                ]
+              }
+            ]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+  })
+})

--- a/characterisation/exceptions/HO200109/HO200109-APPHRD-SUBVAR.test.ts
+++ b/characterisation/exceptions/HO200109/HO200109-APPHRD-SUBVAR.test.ts
@@ -1,0 +1,105 @@
+import World from "../../../utils/world"
+import generatePhase2Message from "../../helpers/generatePhase2Message"
+import { processPhase2Message } from "../../helpers/processMessage"
+import { asnPath } from "../../helpers/errorPaths"
+import MessageType from "../../types/MessageType"
+import { ResultClass } from "../../types/ResultClass"
+
+describe.ifPhase2("HO200109", () => {
+  afterAll(async () => {
+    await new World({}).db.closeConnection()
+  })
+
+  describe("when the input message generates an APPHRD and SUBVAR operation", () => {
+    describe("with results including appeal outcome and sentence as well as 2007 PNC disposal", () => {
+      it.each([MessageType.ANNOTATED_HEARING_OUTCOME, MessageType.PNC_UPDATE_DATASET])(
+        "creates a HO200109 exception for %s",
+        async (messageType) => {
+          const inputMessage = generatePhase2Message({
+            messageType,
+            penaltyNoticeCaseReference: false,
+            offences: [
+              {
+                results: [
+                  { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                  { resultClass: ResultClass.SENTENCE, pncAdjudicationExists: true }
+                ]
+              }
+            ],
+            pncAdjudication: true,
+            pncDisposals: [{ type: 2007 }]
+          })
+
+          const {
+            outputMessage: { Exceptions: exceptions }
+          } = await processPhase2Message(inputMessage)
+
+          expect(exceptions).toStrictEqual([
+            {
+              code: "HO200109",
+              path: asnPath
+            }
+          ])
+        }
+      )
+    })
+
+    describe("with results including appeal outcome and judgement with final result", () => {
+      it(`creates a HO200109 exception for ${MessageType.ANNOTATED_HEARING_OUTCOME} with 2007 PNC disposal`, async () => {
+        const inputMessage = generatePhase2Message({
+          messageType: MessageType.ANNOTATED_HEARING_OUTCOME,
+          penaltyNoticeCaseReference: false,
+          offences: [
+            {
+              results: [
+                { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                { resultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, pncAdjudicationExists: true }
+              ]
+            }
+          ],
+          pncAdjudication: true,
+          pncDisposals: [{ type: 2007 }]
+        })
+
+        const {
+          outputMessage: { Exceptions: exceptions }
+        } = await processPhase2Message(inputMessage)
+
+        expect(exceptions).toStrictEqual([
+          {
+            code: "HO200109",
+            path: asnPath
+          }
+        ])
+      })
+
+      it(`creates a HO200109 exception for ${MessageType.PNC_UPDATE_DATASET} without 2007 PNC disposal`, async () => {
+        const inputMessage = generatePhase2Message({
+          messageType: MessageType.PNC_UPDATE_DATASET,
+          penaltyNoticeCaseReference: false,
+          offences: [
+            {
+              results: [
+                { resultClass: ResultClass.APPEAL_OUTCOME, pncAdjudicationExists: true },
+                { resultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, pncAdjudicationExists: true }
+              ]
+            }
+          ],
+          pncAdjudication: true,
+          pncDisposals: [{ type: 1000 }]
+        })
+
+        const {
+          outputMessage: { Exceptions: exceptions }
+        } = await processPhase2Message(inputMessage)
+
+        expect(exceptions).toStrictEqual([
+          {
+            code: "HO200109",
+            path: asnPath
+          }
+        ])
+      })
+    })
+  })
+})

--- a/characterisation/helpers/generatePhase2Message.ts
+++ b/characterisation/helpers/generatePhase2Message.ts
@@ -41,11 +41,12 @@ type Offence = {
   recordableOnPncIndicator?: boolean
   addedByTheCourt?: boolean
   results?: Result[]
-  courtCaseReferenceNumber?: true
+  courtCaseReferenceNumber?: boolean
 }
 
 export type GeneratePhase2MessageOptions = {
   messageType: MessageType
+  penaltyNoticeCaseReference?: boolean
   recordableOnPncIndicator?: boolean
   arrestSummonsNumber?: string
   offences?: Offence[]

--- a/characterisation/test-data/Phase2Message.xml.njk
+++ b/characterisation/test-data/Phase2Message.xml.njk
@@ -40,6 +40,9 @@
       <br7:CourtReference>
         <ds:MagistratesCourtReference>01ZD0303208</ds:MagistratesCourtReference>
       </br7:CourtReference>
+      {% if penaltyNoticeCaseReference %}
+      <br7:PenaltyNoticeCaseReference>12345</br7:PenaltyNoticeCaseReference>
+      {% endif %}
       {% if recordableOnPncIndicator or recordableOnPncIndicator == undefined %}
       <br7:RecordableOnPNCindicator Literal="Yes">Y</br7:RecordableOnPNCindicator>
       {% else %}


### PR DESCRIPTION
## Context

The HO200109 exception can be raised with a number of different combination of operations that aren't valid. These combination of operations can be raised with different combinations of offence result types.

For Core, this happens in [`validateOperations`](https://github.com/ministryofjustice/bichard7-next-core/blob/main/packages/core/phase2/lib/getOperationSequence/validateOperations.ts) and we check for different combination of operations in 5 different places.

The invalid combination of operations for HO200109 are:

1. APPHRD and DISARR
2. APPHRD and NEWREM (with and without remand court case references)
3. APPHRD and PENHRG
4. APPHRD and SENDEF
5. APPHRD and SUBVAR
6. APPHRD and COMSEN
7. SENDEF and COMSEN
8. SUBVAR and PENHRG
9. Duplicated APPHRD, COMSEN, SENDEF, SUBVAR and DISARR

The last four combinations aren't possible because we don't raise COMSEN and the logic to generate SUBVAR and PENHRG conflict on fixed penalty and we deduplicate before we validating operations.

## Changes proposed in this PR

- Add HO200109 characterisation tests that targets all the possible combinations of invalid operations and the different ways that those operations may be generated.
  - We've split these tests into different files because they take long to run against legacy Bichard and therefore takes Jest long to output any logs when in a single file. This caused CircleCI to time out on the step to run these tests i.e. `Too long with no output (exceeded 10m0s)`.
  - They've also been wrapped in different `describe` blocks for readability and understanding where they are targeting in `validateOperations`.
  - It's worth noting that these tests make the Phase 2 characterisation tests for legacy Bichard take a significantly longer amount of time although for Core they're quick.
    - One idea I have is only running characterisation tests when there are changes within the `characterisation` folder like we do in Core. Any thoughts?

![image](https://github.com/user-attachments/assets/47d33d0e-3548-40e7-b866-47c2f42c969c)
![image](https://github.com/user-attachments/assets/011d6015-a940-4446-9a5f-c786c629cc26)

https://dsdmoj.atlassian.net/browse/BICAWS7-3052