### PR TITLE
Improve the way querying for triggers works which also speeds up the tests

### DIFF
--- a/characterisation/exceptions/HO100103.test.ts
+++ b/characterisation/exceptions/HO100103.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100103", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100103",
@@ -32,9 +30,7 @@ describe.ifPhase1("HO100103", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100103",
@@ -49,9 +45,7 @@ describe.ifPhase1("HO100103", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100103",
@@ -66,9 +60,7 @@ describe.ifPhase1("HO100103", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100103",
@@ -83,9 +75,7 @@ describe.ifPhase1("HO100103", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100103",
@@ -111,9 +101,7 @@ describe.ifPhase1("HO100103", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100103",

--- a/characterisation/exceptions/HO100106.test.ts
+++ b/characterisation/exceptions/HO100106.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100107", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100106",

--- a/characterisation/exceptions/HO100107.test.ts
+++ b/characterisation/exceptions/HO100107.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100107", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100107",

--- a/characterisation/exceptions/HO100108.test.ts
+++ b/characterisation/exceptions/HO100108.test.ts
@@ -16,9 +16,7 @@ describe.ifPhase1("HO100108", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -35,9 +33,7 @@ describe.ifPhase1("HO100108", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -64,9 +60,7 @@ describe.ifPhase1("HO100108", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -93,9 +87,7 @@ describe.ifPhase1("HO100108", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100200.test.ts
+++ b/characterisation/exceptions/HO100200.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100200", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100200",

--- a/characterisation/exceptions/HO100201.test.ts
+++ b/characterisation/exceptions/HO100201.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100201", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       { code: "HO100201", path: ["AnnotatedHearingOutcome", "HearingOutcome", "Case", "PTIURN"] }

--- a/characterisation/exceptions/HO100206.test.ts
+++ b/characterisation/exceptions/HO100206.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("HO100206", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -34,9 +32,7 @@ describe.ifPhase1("HO100206", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100209.test.ts
+++ b/characterisation/exceptions/HO100209.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100209", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100211.test.ts
+++ b/characterisation/exceptions/HO100211.test.ts
@@ -16,9 +16,7 @@ describe.ifPhase1("HO100211", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -44,9 +42,7 @@ describe.ifPhase1("HO100211", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100212.test.ts
+++ b/characterisation/exceptions/HO100212.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100212", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100213.test.ts
+++ b/characterisation/exceptions/HO100213.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100213", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -44,9 +42,7 @@ describe.ifPhase1("HO100213", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -73,9 +69,7 @@ describe.ifPhase1("HO100213", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100215.test.ts
+++ b/characterisation/exceptions/HO100215.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100215", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -43,9 +41,7 @@ describe.ifPhase1("HO100215", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100217.test.ts
+++ b/characterisation/exceptions/HO100217.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100217", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -35,9 +33,7 @@ describe.ifPhase1("HO100217", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -55,9 +51,7 @@ describe.ifPhase1("HO100217", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -75,9 +69,7 @@ describe.ifPhase1("HO100217", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -95,9 +87,7 @@ describe.ifPhase1("HO100217", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -115,9 +105,7 @@ describe.ifPhase1("HO100217", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -135,9 +123,7 @@ describe.ifPhase1("HO100217", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -155,9 +141,7 @@ describe.ifPhase1("HO100217", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -175,9 +159,7 @@ describe.ifPhase1("HO100217", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -195,9 +177,7 @@ describe.ifPhase1("HO100217", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100220.test.ts
+++ b/characterisation/exceptions/HO100220.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100220", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100220",
@@ -33,9 +31,7 @@ describe.ifPhase1("HO100220", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100220",

--- a/characterisation/exceptions/HO100228_239.test.ts
+++ b/characterisation/exceptions/HO100228_239.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100228 and HO100239", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toHaveLength(0)
   })
@@ -31,9 +29,7 @@ describe.ifPhase1("HO100228 and HO100239", () => {
 
       const {
         hearingOutcome: { Exceptions: exceptions }
-      } = await processPhase1Message(inputMessage, {
-        expectTriggers: false
-      })
+      } = await processPhase1Message(inputMessage)
 
       expect(exceptions).toStrictEqual([
         {
@@ -74,9 +70,7 @@ describe.ifPhase1("HO100228 and HO100239", () => {
 
       const {
         hearingOutcome: { Exceptions: exceptions }
-      } = await processPhase1Message(inputMessage, {
-        expectTriggers: false
-      })
+      } = await processPhase1Message(inputMessage)
 
       expect(exceptions).toStrictEqual([
         {

--- a/characterisation/exceptions/HO100232.test.ts
+++ b/characterisation/exceptions/HO100232.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("HO100232", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toHaveLength(0)
   })
@@ -28,9 +26,7 @@ describe.ifPhase1("HO100232", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -55,9 +51,7 @@ describe.ifPhase1("HO100232", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100233.test.ts
+++ b/characterisation/exceptions/HO100233.test.ts
@@ -30,9 +30,7 @@ describe.ifPhase1("HO100233", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toHaveLength(0)
     expect(lookupOffenceByCjsCode).toHaveBeenCalled()
@@ -56,9 +54,7 @@ describe.ifPhase1("HO100233", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -86,9 +82,7 @@ describe.ifPhase1("HO100233", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100234.test.ts
+++ b/characterisation/exceptions/HO100234.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("validate hearing outcome", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toHaveLength(0)
   })
@@ -28,9 +26,7 @@ describe.ifPhase1("validate hearing outcome", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -55,9 +51,7 @@ describe.ifPhase1("validate hearing outcome", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100236.test.ts
+++ b/characterisation/exceptions/HO100236.test.ts
@@ -35,9 +35,7 @@ describe.ifPhase1("HO100236", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toHaveLength(0)
     expect(lookupOffenceByCjsCode).toHaveBeenCalled()
@@ -61,9 +59,7 @@ describe.ifPhase1("HO100236", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -99,9 +95,7 @@ describe.ifPhase1("HO100236", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100237.test.ts
+++ b/characterisation/exceptions/HO100237.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("HO100237", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100237",

--- a/characterisation/exceptions/HO100240_246.test.ts
+++ b/characterisation/exceptions/HO100240_246.test.ts
@@ -45,9 +45,7 @@ describe.ifPhase1("HO100240 and HO100246", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual(expectedExceptions)
   })
@@ -60,9 +58,7 @@ describe.ifPhase1("HO100240 and HO100246", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual(expectedExceptions)
   })

--- a/characterisation/exceptions/HO100242.test.ts
+++ b/characterisation/exceptions/HO100242.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("HO100242", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100242",
@@ -43,9 +41,7 @@ describe.ifPhase1("HO100242", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100242",

--- a/characterisation/exceptions/HO100243.test.ts
+++ b/characterisation/exceptions/HO100243.test.ts
@@ -32,9 +32,7 @@ describe.ifPhase1("HO100243", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toHaveLength(0)
   })
@@ -48,9 +46,7 @@ describe.ifPhase1("HO100243", () => {
 
       const {
         hearingOutcome: { Exceptions: exceptions }
-      } = await processPhase1Message(inputMessage, {
-        expectTriggers: false
-      })
+      } = await processPhase1Message(inputMessage)
 
       expect(exceptions).toStrictEqual(expectedExceptions)
     }
@@ -63,9 +59,7 @@ describe.ifPhase1("HO100243", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual(expectedExceptions)
   })
@@ -77,9 +71,7 @@ describe.ifPhase1("HO100243", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual(expectedExceptions)
   })
@@ -93,9 +85,7 @@ describe.ifPhase1("HO100243", () => {
 
       const {
         hearingOutcome: { Exceptions: exceptions }
-      } = await processPhase1Message(inputMessage, {
-        expectTriggers: false
-      })
+      } = await processPhase1Message(inputMessage)
 
       expect(exceptions).toStrictEqual(expectedExceptions)
     }

--- a/characterisation/exceptions/HO100244.test.ts
+++ b/characterisation/exceptions/HO100244.test.ts
@@ -32,9 +32,7 @@ describe.ifPhase1("HO100244", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toHaveLength(0)
   })
@@ -46,9 +44,7 @@ describe.ifPhase1("HO100244", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual(expectedExceptions)
   })
@@ -60,9 +56,7 @@ describe.ifPhase1("HO100244", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual(expectedExceptions)
   })

--- a/characterisation/exceptions/HO100245.test.ts
+++ b/characterisation/exceptions/HO100245.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("HO100245", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100247.test.ts
+++ b/characterisation/exceptions/HO100247.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("HO100247", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100247",
@@ -43,9 +41,7 @@ describe.ifPhase1("HO100247", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100247",

--- a/characterisation/exceptions/HO100249.test.ts
+++ b/characterisation/exceptions/HO100249.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100249", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toContainEqual({
       code: "HO100249",

--- a/characterisation/exceptions/HO100251.test.ts
+++ b/characterisation/exceptions/HO100251.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("HO100306", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toHaveLength(0)
   })
@@ -30,9 +28,7 @@ describe.ifPhase1("HO100306", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100300.test.ts
+++ b/characterisation/exceptions/HO100300.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100300", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -35,9 +33,7 @@ describe.ifPhase1("HO100300", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -72,9 +68,7 @@ describe.ifPhase1("HO100300", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100305.test.ts
+++ b/characterisation/exceptions/HO100305.test.ts
@@ -15,9 +15,7 @@ describe.ifPhase1("HO100305", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {
@@ -36,9 +34,7 @@ describe.ifPhase1("HO100305", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100306.test.ts
+++ b/characterisation/exceptions/HO100306.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("HO100306", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toHaveLength(0)
   })
@@ -28,9 +26,7 @@ describe.ifPhase1("HO100306", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100307.test.ts
+++ b/characterisation/exceptions/HO100307.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("HO100307", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100309.test.ts
+++ b/characterisation/exceptions/HO100309.test.ts
@@ -14,9 +14,7 @@ describe.ifPhase1("HO100309", () => {
 
     const {
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, {
-      expectTriggers: false
-    })
+    } = await processPhase1Message(inputMessage)
 
     expect(exceptions).toStrictEqual([
       {

--- a/characterisation/exceptions/HO100321.test.ts
+++ b/characterisation/exceptions/HO100321.test.ts
@@ -18,7 +18,6 @@ describe.ifPhase1("HO100321", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: true
     })
 
@@ -45,7 +44,6 @@ describe.ifPhase1("HO100321", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: false
     })
 

--- a/characterisation/exceptions/HO100322_323.test.ts
+++ b/characterisation/exceptions/HO100322_323.test.ts
@@ -20,7 +20,6 @@ describe.ifPhase1("HO100322", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: true
     })
 
@@ -72,7 +71,6 @@ describe.ifPhase1("HO100322", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: false
     })
 

--- a/characterisation/exceptions/HO100324.test.ts
+++ b/characterisation/exceptions/HO100324.test.ts
@@ -23,7 +23,6 @@ describe.ifPhase1("HO100324", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: true,
       pncAdjudication: true
     })
@@ -71,7 +70,6 @@ describe.ifPhase1("HO100324", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: true,
       pncAdjudication: true,
       pncMessage

--- a/characterisation/exceptions/HO100325.test.ts
+++ b/characterisation/exceptions/HO100325.test.ts
@@ -22,7 +22,6 @@ describe.ifPhase1("HO100325", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: true
     })
 
@@ -66,7 +65,6 @@ describe.ifPhase1("HO100325", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: true,
       pncMessage
     })

--- a/characterisation/exceptions/HO100326.test.ts
+++ b/characterisation/exceptions/HO100326.test.ts
@@ -16,7 +16,6 @@ describe.ifPhase1("HO100326", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: true
     })
 
@@ -43,7 +42,6 @@ describe.ifPhase1("HO100326", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: true,
       pncMessage
     })

--- a/characterisation/exceptions/HO100331.test.ts
+++ b/characterisation/exceptions/HO100331.test.ts
@@ -15,7 +15,6 @@ describe.ifPhase1("HO100331", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: true
     })
 

--- a/characterisation/exceptions/HO100507.test.ts
+++ b/characterisation/exceptions/HO100507.test.ts
@@ -1,5 +1,5 @@
-import generateSpiMessage from "../helpers/generateSpiMessage"
 import World from "../../utils/world"
+import generateSpiMessage from "../helpers/generateSpiMessage"
 import { processPhase1Message } from "../helpers/processMessage"
 
 describe.ifPhase1("HO100507", () => {
@@ -22,7 +22,6 @@ describe.ifPhase1("HO100507", () => {
     const {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       recordable: true,
       pncCaseType: "penalty",
       pncMessage

--- a/characterisation/exceptions/HO200100.test.ts
+++ b/characterisation/exceptions/HO200100.test.ts
@@ -1,8 +1,8 @@
 import World from "../../utils/world"
-import { processPhase2Message } from "../helpers/processMessage"
 import { offenceResultClassPath } from "../helpers/errorPaths"
-import MessageType from "../types/MessageType"
 import generatePhase2Message from "../helpers/generatePhase2Message"
+import { processPhase2Message } from "../helpers/processMessage"
+import MessageType from "../types/MessageType"
 import { ResultClass } from "../types/ResultClass"
 
 describe.ifPhase2("HO200100", () => {
@@ -50,7 +50,7 @@ describe.ifPhase2("HO200100", () => {
 
         const {
           outputMessage: { Exceptions: exceptions }
-        } = await processPhase2Message(inputMessage, { expectTriggers: false, expectRecord: false })
+        } = await processPhase2Message(inputMessage, { expectRecord: false })
 
         expect(exceptions).toHaveLength(0)
       }

--- a/characterisation/exceptions/HO200101.test.ts
+++ b/characterisation/exceptions/HO200101.test.ts
@@ -1,7 +1,7 @@
 import World from "../../utils/world"
-import { processPhase2Message } from "../helpers/processMessage"
 import { offenceResultClassPath } from "../helpers/errorPaths"
 import generatePhase2Message from "../helpers/generatePhase2Message"
+import { processPhase2Message } from "../helpers/processMessage"
 import MessageType from "../types/MessageType"
 import { ResultClass } from "../types/ResultClass"
 
@@ -53,7 +53,7 @@ describe.ifPhase2("HO200101", () => {
 
       const {
         outputMessage: { Exceptions: exceptions }
-      } = await processPhase2Message(inputMessage, { expectTriggers: false, ...processMessageOptions })
+      } = await processPhase2Message(inputMessage, processMessageOptions)
 
       expect(exceptions).not.toContainEqual({
         code: "HO200101",

--- a/characterisation/exceptions/HO200104.test.ts
+++ b/characterisation/exceptions/HO200104.test.ts
@@ -1,9 +1,9 @@
 import World from "../../utils/world"
 import { offenceResultClassPath } from "../helpers/errorPaths"
-import { processPhase2Message } from "../helpers/processMessage"
-import { ResultClass } from "../types/ResultClass"
-import MessageType from "../types/MessageType"
 import generatePhase2Message from "../helpers/generatePhase2Message"
+import { processPhase2Message } from "../helpers/processMessage"
+import MessageType from "../types/MessageType"
+import { ResultClass } from "../types/ResultClass"
 
 describe.ifPhase2("HO200104", () => {
   afterAll(async () => {
@@ -56,7 +56,7 @@ describe.ifPhase2("HO200104", () => {
 
     const {
       outputMessage: { Exceptions: exceptions }
-    } = await processPhase2Message(pncUpdateDataset, { expectTriggers: false, expectRecord: false })
+    } = await processPhase2Message(pncUpdateDataset, { expectRecord: false })
 
     expect(exceptions).toHaveLength(0)
   })
@@ -70,7 +70,7 @@ describe.ifPhase2("HO200104", () => {
 
     const {
       outputMessage: { Exceptions: exceptions }
-    } = await processPhase2Message(pncUpdateDataset, { expectTriggers: false, expectRecord: false })
+    } = await processPhase2Message(pncUpdateDataset, { expectRecord: false })
 
     expect(exceptions).toHaveLength(0)
   })

--- a/characterisation/exceptions/HO200106.test.ts
+++ b/characterisation/exceptions/HO200106.test.ts
@@ -1,8 +1,8 @@
 import World from "../../utils/world"
 import { offenceResultClassPath } from "../helpers/errorPaths"
+import generatePhase2Message from "../helpers/generatePhase2Message"
 import { processPhase2Message } from "../helpers/processMessage"
 import MessageType from "../types/MessageType"
-import generatePhase2Message from "../helpers/generatePhase2Message"
 import { ResultClass } from "../types/ResultClass"
 
 describe.ifPhase2("HO200106", () => {
@@ -50,7 +50,7 @@ describe.ifPhase2("HO200106", () => {
 
       const {
         outputMessage: { Exceptions: exceptions }
-      } = await processPhase2Message(inputMessage, { expectTriggers: false, expectRecord: false })
+      } = await processPhase2Message(inputMessage, { expectRecord: false })
 
       expect(exceptions).not.toContainEqual({
         code: "HO200106",

--- a/characterisation/exceptions/HO200107.test.ts
+++ b/characterisation/exceptions/HO200107.test.ts
@@ -1,8 +1,8 @@
 import World from "../../utils/world"
-import { processPhase2Message } from "../helpers/processMessage"
 import { offenceResultClassPath } from "../helpers/errorPaths"
-import MessageType from "../types/MessageType"
 import generatePhase2Message from "../helpers/generatePhase2Message"
+import { processPhase2Message } from "../helpers/processMessage"
+import MessageType from "../types/MessageType"
 import { ResultClass } from "../types/ResultClass"
 
 describe.ifPhase2("HO200107", () => {
@@ -50,7 +50,7 @@ describe.ifPhase2("HO200107", () => {
 
         const {
           outputMessage: { Exceptions: exceptions }
-        } = await processPhase2Message(inputMessage, { expectTriggers: false, expectRecord: false })
+        } = await processPhase2Message(inputMessage, { expectRecord: false })
 
         expect(exceptions).toHaveLength(0)
       }

--- a/characterisation/exceptions/HO200108.test.ts
+++ b/characterisation/exceptions/HO200108.test.ts
@@ -1,9 +1,9 @@
 import World from "../../utils/world"
-import { processPhase2Message } from "../helpers/processMessage"
 import { offenceResultClassPath } from "../helpers/errorPaths"
+import generatePhase2Message from "../helpers/generatePhase2Message"
+import { processPhase2Message } from "../helpers/processMessage"
 import MessageType from "../types/MessageType"
 import { ResultClass } from "../types/ResultClass"
-import generatePhase2Message from "../helpers/generatePhase2Message"
 
 describe.ifPhase2("HO200108", () => {
   afterAll(async () => {
@@ -63,7 +63,7 @@ describe.ifPhase2("HO200108", () => {
 
     const {
       outputMessage: { Exceptions: exceptions }
-    } = await processPhase2Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    } = await processPhase2Message(inputMessage, { expectRecord: false })
 
     expect(exceptions).not.toContainEqual({
       code: "HO200108",

--- a/characterisation/exceptions/HO200110.test.ts
+++ b/characterisation/exceptions/HO200110.test.ts
@@ -1,7 +1,7 @@
 import World from "../../utils/world"
+import { asnPath } from "../helpers/errorPaths"
 import generatePhase2Message from "../helpers/generatePhase2Message"
 import { processPhase2Message } from "../helpers/processMessage"
-import { asnPath } from "../helpers/errorPaths"
 import MessageType from "../types/MessageType"
 
 describe.ifPhase2("HO200110", () => {
@@ -43,7 +43,7 @@ describe.ifPhase2("HO200110", () => {
 
       const {
         outputMessage: { Exceptions: exceptions }
-      } = await processPhase2Message(inputMessage, { expectTriggers: false, expectRecord: false })
+      } = await processPhase2Message(inputMessage, { expectRecord: false })
 
       expect(exceptions).not.toContainEqual({
         code: "HO200110",

--- a/characterisation/exceptions/HO200121.test.ts
+++ b/characterisation/exceptions/HO200121.test.ts
@@ -1,7 +1,7 @@
 import World from "../../utils/world"
+import { asnPath } from "../helpers/errorPaths"
 import generatePhase2Message from "../helpers/generatePhase2Message"
 import { processPhase2Message } from "../helpers/processMessage"
-import { asnPath } from "../helpers/errorPaths"
 import MessageType from "../types/MessageType"
 
 describe.ifPhase2("HO200121", () => {
@@ -50,7 +50,7 @@ describe.ifPhase2("HO200121", () => {
 
     const {
       outputMessage: { Exceptions: exceptions }
-    } = await processPhase2Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    } = await processPhase2Message(inputMessage, { expectRecord: false })
 
     expect(exceptions).not.toContainEqual({
       code: "HO200121",

--- a/characterisation/exceptions/HO200212.test.ts
+++ b/characterisation/exceptions/HO200212.test.ts
@@ -50,7 +50,7 @@ describe.ifPhase2("HO200212", () => {
 
       const {
         outputMessage: { Exceptions: exceptions }
-      } = await processPhase2Message(inputMessage, { expectTriggers: false, expectRecord: false })
+      } = await processPhase2Message(inputMessage, { expectRecord: false })
 
       expect(exceptions).toHaveLength(0)
     }

--- a/characterisation/helpers/processMessage.ts
+++ b/characterisation/helpers/processMessage.ts
@@ -1,13 +1,12 @@
 import type BichardPhase1ResultType from "../types/BichardPhase1ResultType"
+import type BichardPhase2ResultType from "../types/BichardPhase2ResultType"
 import type { ResultedCaseMessageParsedXml } from "../types/IncomingMessage"
+import Phase from "../types/Phase"
 import processMessageBichard from "./processMessageBichard"
 import processMessageCore from "./processMessageCore"
-import Phase from "../types/Phase"
-import type BichardPhase2ResultType from "../types/BichardPhase2ResultType"
 
 export type ProcessMessageOptions = {
   expectRecord?: boolean
-  expectTriggers?: boolean
   recordable?: boolean
   pncCaseType?: string
   pncOverrides?: Partial<ResultedCaseMessageParsedXml>

--- a/characterisation/helpers/processMessageBichard.ts
+++ b/characterisation/helpers/processMessageBichard.ts
@@ -4,11 +4,12 @@ import type ActiveMqHelper from "../../helpers/ActiveMqHelper"
 import type PostgresHelper from "../../helpers/PostgresHelper"
 import World from "../../utils/world"
 import type { AnnotatedHearingOutcome, AnnotatedPncUpdateDataset } from "../types/AnnotatedHearingOutcome"
+import Phase from "../types/Phase"
+import { Trigger } from "../types/Trigger"
+import type { TriggerCode } from "../types/TriggerCode"
 import extractExceptionsFromAho from "./extractExceptionsFromAho"
 import { mockEnquiryErrorInPnc, mockRecordInPnc } from "./mockRecordInPnc"
 import type { ProcessMessageOptions } from "./processMessage"
-import Phase from "../types/Phase"
-import type { TriggerCode } from "../types/TriggerCode"
 
 type TriggerEntity = { trigger_code: TriggerCode; trigger_item_identity?: string }
 
@@ -21,7 +22,6 @@ const processMessageBichard = async <BichardResultType>(
   messageXml: string,
   {
     expectRecord = true,
-    expectTriggers = true,
     recordable = true,
     pncOverrides = {},
     pncCaseType = "court",
@@ -32,10 +32,6 @@ const processMessageBichard = async <BichardResultType>(
 ): Promise<BichardResultType> => {
   const correlationId = uuid()
   const messageXmlWithUuid = messageXml.replace("EXTERNAL_CORRELATION_ID", correlationId)
-
-  if (expectTriggers && !expectRecord) {
-    throw new Error("You can't expect triggers without a record.")
-  }
 
   if (phase === Phase.HEARING_OUTCOME && !realPnc) {
     if (recordable) {
@@ -76,29 +72,32 @@ const processMessageBichard = async <BichardResultType>(
       : extractExceptionsFromAho<AnnotatedPncUpdateDataset>(recordResult.annotated_msg)
     : []
 
-  // Wait for the record to appear in Postgres
-  const triggerQuery = `SELECT t.trigger_code, t.trigger_item_identity FROM br7own.error_list AS e
+  let triggers: Trigger[] = []
+  if (expectRecord) {
+    // Wait for the record to appear in Postgres
+    const triggerQuery = `SELECT t.trigger_code, t.trigger_item_identity FROM br7own.error_list AS e
     INNER JOIN br7own.error_list_triggers AS t ON t.error_id = e.error_id
     WHERE message_id = '${correlationId}'
     ORDER BY t.trigger_item_identity ASC`
 
-  if (!expectTriggers && !(expectRecord && recordResult)) {
-    await new Promise((resolve) => setTimeout(resolve, 3_000))
+    if (!(expectRecord && recordResult)) {
+      await new Promise((resolve) => setTimeout(resolve, 3_000))
+    }
+
+    const fetchTriggers = () => pg.manyOrNone(triggerQuery)
+
+    const triggerResult =
+      (await promisePoller<TriggerEntity[]>({
+        taskFn: fetchTriggers,
+        interval: 20,
+        retries: 1000
+      }).catch(() => [])) ?? []
+
+    triggers = triggerResult.map((record) => ({
+      code: record.trigger_code,
+      ...(record.trigger_item_identity ? { offenceSequenceNumber: parseInt(record.trigger_item_identity, 10) } : {})
+    }))
   }
-
-  const fetchTriggers = () => (expectTriggers ? pg.many(triggerQuery) : pg.none(triggerQuery))
-
-  const triggerResult =
-    (await promisePoller<TriggerEntity[]>({
-      taskFn: fetchTriggers,
-      interval: 20,
-      retries: 1000
-    }).catch(() => [])) ?? []
-
-  const triggers = triggerResult.map((record) => ({
-    code: record.trigger_code,
-    ...(record.trigger_item_identity ? { offenceSequenceNumber: parseInt(record.trigger_item_identity, 10) } : {})
-  }))
 
   if (phase === Phase.HEARING_OUTCOME) {
     return { triggers, hearingOutcome: { Exceptions: exceptions } as AnnotatedHearingOutcome } as BichardResultType

--- a/characterisation/triggers/TRPR0002.test.ts
+++ b/characterisation/triggers/TRPR0002.test.ts
@@ -35,7 +35,7 @@ describe.ifPhase1("TRPR0002", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })
@@ -58,7 +58,7 @@ describe.ifPhase1("TRPR0002", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })

--- a/characterisation/triggers/TRPR0003.test.ts
+++ b/characterisation/triggers/TRPR0003.test.ts
@@ -50,7 +50,7 @@ describe.ifPhase1("TRPR0003", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })
@@ -64,7 +64,7 @@ describe.ifPhase1("TRPR0003", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })

--- a/characterisation/triggers/TRPR0004.test.ts
+++ b/characterisation/triggers/TRPR0004.test.ts
@@ -74,7 +74,7 @@ describe.ifPhase1("TRPR0004", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })
@@ -89,7 +89,7 @@ describe.ifPhase1("TRPR0004", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })

--- a/characterisation/triggers/TRPR0008.test.ts
+++ b/characterisation/triggers/TRPR0008.test.ts
@@ -57,7 +57,7 @@ describe.ifPhase1("TRPR0008", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })
@@ -78,7 +78,7 @@ describe.ifPhase1("TRPR0008", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })
@@ -94,7 +94,7 @@ describe.ifPhase1("TRPR0008", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })

--- a/characterisation/triggers/TRPR0010.test.ts
+++ b/characterisation/triggers/TRPR0010.test.ts
@@ -64,7 +64,7 @@ describe.ifPhase1("TRPR0010", () => {
     const {
       triggers,
       hearingOutcome: { Exceptions: exceptions }
-    } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
     expect(exceptions).toHaveLength(0)

--- a/characterisation/triggers/TRPR0015.test.ts
+++ b/characterisation/triggers/TRPR0015.test.ts
@@ -68,7 +68,6 @@ describe.ifPhase1("TRPR0015", () => {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
       recordable: false,
-      expectTriggers: false,
       expectRecord: false
     })
 

--- a/characterisation/triggers/TRPR0018.test.ts
+++ b/characterisation/triggers/TRPR0018.test.ts
@@ -119,7 +119,6 @@ describe.ifPhase1("TRPR0018", () => {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
       expectRecord: false,
-      expectTriggers: false,
       ...pncOffenceDateOverrides([{ startDate: "2021-02-28" }])
     })
 
@@ -143,7 +142,6 @@ describe.ifPhase1("TRPR0018", () => {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
       expectRecord: false,
-      expectTriggers: false,
       ...pncOffenceDateOverrides([{ startDate: "2021-01-28", endDate: "2021-02-28" }])
     })
 
@@ -167,7 +165,6 @@ describe.ifPhase1("TRPR0018", () => {
       hearingOutcome: { Exceptions: exceptions }
     } = await processPhase1Message(inputMessage, {
       expectRecord: false,
-      expectTriggers: false,
       ...pncOffenceDateOverrides([{ startDate: "2021-02-28", endDate: "2021-02-28" }])
     })
 

--- a/characterisation/triggers/TRPR0020.test.ts
+++ b/characterisation/triggers/TRPR0020.test.ts
@@ -89,7 +89,7 @@ describe.ifPhase1("TRPR0020", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })
@@ -105,7 +105,7 @@ describe.ifPhase1("TRPR0020", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })

--- a/characterisation/triggers/TRPR0025.test.ts
+++ b/characterisation/triggers/TRPR0025.test.ts
@@ -37,7 +37,7 @@ describe.ifPhase1("TRPR0025", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false, expectRecord: false })
+    const { triggers } = await processPhase1Message(inputMessage, { expectRecord: false })
 
     expect(triggers).toHaveLength(0)
   })
@@ -51,7 +51,7 @@ describe.ifPhase1("TRPR0025", () => {
       ]
     })
 
-    const { triggers } = await processPhase1Message(inputMessage, { expectTriggers: false })
+    const { triggers } = await processPhase1Message(inputMessage)
 
     expect(triggers).toHaveLength(0)
   })

--- a/characterisation/triggers/TRPR0029.test.ts
+++ b/characterisation/triggers/TRPR0029.test.ts
@@ -72,7 +72,6 @@ describe.ifPhase1("TRPR0029", () => {
     })
 
     const { triggers } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       expectRecord: false,
       recordable: false
     })
@@ -92,7 +91,6 @@ describe.ifPhase1("TRPR0029", () => {
 
     const { triggers } = await processPhase1Message(inputMessage, {
       recordable: true,
-      expectTriggers: false,
       expectRecord: false
     })
 

--- a/characterisation/triggers/TRPR0030.test.ts
+++ b/characterisation/triggers/TRPR0030.test.ts
@@ -41,7 +41,6 @@ describe.ifPhase1("TRPR0030", () => {
     })
 
     const { triggers } = await processPhase1Message(inputMessage, {
-      expectTriggers: false,
       expectRecord: false
     })
 


### PR DESCRIPTION
Previously there was an `expectTriggers` flag you could pass if you did or didn't expect there to be triggers - this removes the flag and just fetches all of the triggers if there's a record expected so that you can still check them in the tests.

Why does this matter? If you didn't pass `expectTriggers: false` when you weren't expecting triggers, the test would wait for 20 seconds to see if there were any. This is why the tests were slow