### PR TITLE
Add HO200115 characterisation tests

### DIFF
--- a/characterisation/exceptions/HO200115.test.ts
+++ b/characterisation/exceptions/HO200115.test.ts
@@ -1,0 +1,184 @@
+import World from "../../utils/world"
+import generatePhase2Message from "../helpers/generatePhase2Message"
+import { processPhase2Message } from "../helpers/processMessage"
+import MessageType from "../types/MessageType"
+import { ResultClass } from "../types/ResultClass"
+import { asnPath } from "../helpers/errorPaths"
+
+describe.ifPhase2("HO200115", () => {
+  afterAll(async () => {
+    await new World({}).db.closeConnection()
+  })
+
+  describe("when the input message generates a DISARR and SUBVAR operation", () => {
+    const resultsGeneratingSubvar = [
+      ResultClass.JUDGEMENT_WITH_FINAL_RESULT,
+      ResultClass.ADJOURNMENT_WITH_JUDGEMENT,
+      ResultClass.SENTENCE
+    ]
+
+    describe("with results including judgement with final result and not added by the court generates DISARR", () => {
+      resultsGeneratingSubvar.forEach((resultGeneratingSubvar) => {
+        describe(`and ${resultGeneratingSubvar.toLowerCase()} generates SUBVAR`, () => {
+          it.each([
+            { messageType: MessageType.ANNOTATED_HEARING_OUTCOME },
+            { messageType: MessageType.PNC_UPDATE_DATASET }
+          ])("creates a HO200115 exception for $messageType", async ({ messageType }) => {
+            const resultGeneratesDisarr = {
+              resultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT,
+              pncAdjudicationExists: false
+            }
+            const inputMessage = generatePhase2Message({
+              messageType,
+              penaltyNoticeCaseReference: false,
+              offences: [
+                {
+                  addedByTheCourt: false,
+                  results: [resultGeneratesDisarr, { resultClass: resultGeneratingSubvar, pncAdjudicationExists: true }]
+                }
+              ],
+              pncAdjudication: true,
+              pncDisposals: [{ type: 2007 }]
+            })
+
+            const {
+              outputMessage: { Exceptions: exceptions }
+            } = await processPhase2Message(inputMessage)
+
+            expect(exceptions).toStrictEqual([
+              {
+                code: "HO200115",
+                path: asnPath
+              }
+            ])
+          })
+        })
+      })
+    })
+
+    describe("with results including judgement with final result and added by the court generates DISARR", () => {
+      resultsGeneratingSubvar.forEach((resultGeneratingSubvar) => {
+        describe(`and ${resultGeneratingSubvar.toLowerCase()} generates SUBVAR`, () => {
+          it.each([
+            { messageType: MessageType.ANNOTATED_HEARING_OUTCOME },
+            { messageType: MessageType.PNC_UPDATE_DATASET }
+          ])("creates a HO200115 exception for $messageType", async ({ messageType }) => {
+            const resultsGeneratingDisarr = [
+              { resultClass: ResultClass.JUDGEMENT_WITH_FINAL_RESULT, pncAdjudicationExists: false },
+              { resultClass: ResultClass.ADJOURNMENT_PRE_JUDGEMENT, pncAdjudicationExists: false }
+            ]
+            const inputMessage = generatePhase2Message({
+              messageType,
+              penaltyNoticeCaseReference: false,
+              offences: [
+                {
+                  courtCaseReferenceNumber: true,
+                  addedByTheCourt: true,
+                  results: [
+                    ...resultsGeneratingDisarr,
+                    { resultClass: resultGeneratingSubvar, pncAdjudicationExists: true }
+                  ]
+                }
+              ],
+              pncAdjudication: true,
+              pncDisposals: [{ type: 2007 }]
+            })
+
+            const {
+              outputMessage: { Exceptions: exceptions }
+            } = await processPhase2Message(inputMessage)
+
+            expect(exceptions).toStrictEqual([
+              {
+                code: "HO200115",
+                path: asnPath
+              }
+            ])
+          })
+        })
+      })
+    })
+
+    describe("with results including adjournment with judgement and not added by the court generates DISARR", () => {
+      resultsGeneratingSubvar.forEach((resultGeneratingSubvar) => {
+        describe(`and ${resultGeneratingSubvar.toLowerCase()} generates SUBVAR`, () => {
+          it.each([
+            { messageType: MessageType.ANNOTATED_HEARING_OUTCOME },
+            { messageType: MessageType.PNC_UPDATE_DATASET }
+          ])("creates a HO200115 exception for $messageType", async ({ messageType }) => {
+            const resultGeneratesDisarr = {
+              resultClass: ResultClass.ADJOURNMENT_WITH_JUDGEMENT,
+              pncAdjudicationExists: false
+            }
+            const inputMessage = generatePhase2Message({
+              messageType,
+              penaltyNoticeCaseReference: false,
+              offences: [
+                {
+                  addedByTheCourt: false,
+                  results: [resultGeneratesDisarr, { resultClass: resultGeneratingSubvar, pncAdjudicationExists: true }]
+                }
+              ],
+              pncAdjudication: true,
+              pncDisposals: [{ type: 2007 }]
+            })
+
+            const {
+              outputMessage: { Exceptions: exceptions }
+            } = await processPhase2Message(inputMessage)
+
+            expect(exceptions).toStrictEqual([
+              {
+                code: "HO200115",
+                path: asnPath
+              }
+            ])
+          })
+        })
+      })
+    })
+
+    describe("with results including adjournment with judgement and added by the court generates DISARR", () => {
+      resultsGeneratingSubvar.forEach((resultGeneratingSubvar) => {
+        describe(`and ${resultGeneratingSubvar.toLowerCase()} generates SUBVAR`, () => {
+          it.each([
+            { messageType: MessageType.ANNOTATED_HEARING_OUTCOME },
+            { messageType: MessageType.PNC_UPDATE_DATASET }
+          ])("creates a HO200115 exception for $messageType", async ({ messageType }) => {
+            const resultsGeneratingDisarr = [
+              { resultClass: ResultClass.ADJOURNMENT_WITH_JUDGEMENT, pncAdjudicationExists: false },
+              { resultClass: ResultClass.ADJOURNMENT_PRE_JUDGEMENT, pncAdjudicationExists: false }
+            ]
+            const inputMessage = generatePhase2Message({
+              messageType,
+              penaltyNoticeCaseReference: false,
+              offences: [
+                {
+                  courtCaseReferenceNumber: true,
+                  addedByTheCourt: true,
+                  results: [
+                    ...resultsGeneratingDisarr,
+                    { resultClass: resultGeneratingSubvar, pncAdjudicationExists: true }
+                  ]
+                }
+              ],
+              pncAdjudication: true,
+              pncDisposals: [{ type: 2007 }]
+            })
+
+            const {
+              outputMessage: { Exceptions: exceptions }
+            } = await processPhase2Message(inputMessage)
+
+            expect(exceptions).toStrictEqual([
+              {
+                code: "HO200115",
+                path: asnPath
+              }
+            ])
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
- HO200115 can be generated when a combination of PENHRG and DISARR operations or DISARR and SUBVAR operations.
- PENHRG and DISARR isn't possible because they conflict on fixed penalty.
- There are many different combinations of offence result types that can generate a DISARR and SUBVAR operation. These are all tested.

![image](https://github.com/user-attachments/assets/df502525-5642-429f-b3af-23a256cb5506)

![image](https://github.com/user-attachments/assets/7b94e524-f946-4ff3-bcd1-c2a83ba08440)

https://dsdmoj.atlassian.net/browse/BICAWS7-3053