### PR TITLE
Update CI with Phase 2 message forwarder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
       - run:
           name: Build message forwarder image
           working_directory: ~/bichard7-next-core
-          command: docker-compose -f environment/docker-compose.yml build message-forwarder
+          command: docker-compose -f environment/docker-compose.yml build phase-1-message-forwarder phase-2-message-forwarder
 
   build_audit_logging_images:
     steps:


### PR DESCRIPTION
We renamed the Docker Compose service in https://github.com/ministryofjustice/bichard7-next-core/pull/936.

https://dsdmoj.atlassian.net/browse/BICAWS7-2994